### PR TITLE
Extend stats to show number of requests

### DIFF
--- a/rubix-bookkeeper/src/main/java/com/qubole/rubix/bookkeeper/BookKeeper.java
+++ b/rubix-bookkeeper/src/main/java/com/qubole/rubix/bookkeeper/BookKeeper.java
@@ -115,6 +115,8 @@ public class BookKeeper
         Map<String, Double> stats = new HashMap<String, Double>();
         stats.put("Cache Hit Rate", ((double) cachedRequests / totalRequests));
         stats.put("Cache Miss Rate", ((double) (totalRequests - cachedRequests) / totalRequests));
+        stats.put("Cache Reads", ((double) cachedRequests));
+        stats.put("Remote Reads", ((double) (totalRequests  - cachedRequests)));
         return stats;
     }
 


### PR DESCRIPTION
 Extend stats to show number of requests served from cache and from remote 