### PR TITLE
Sockettimeout

### DIFF
--- a/rubix-bookkeeper/src/main/java/com/qubole/rubix/bookkeeper/BookKeeper.java
+++ b/rubix-bookkeeper/src/main/java/com/qubole/rubix/bookkeeper/BookKeeper.java
@@ -93,6 +93,7 @@ public class BookKeeper
         }
 
         if (currentNodeIndex == -1 || nodes == null) {
+            log.error("Initialization not done");
             return null;
         }
 
@@ -195,6 +196,9 @@ public class BookKeeper
                 else {
                     nodes = clusterManager.getNodes();
                 }
+            }
+            if (nodes == null || nodes.size() == 0 || currentNodeIndex == -1) {
+                log.error(String.format("Could not initialize cluster nodes=%s nodeName=%s currentNodeIndex=%d", nodes, nodeName, currentNodeIndex));
             }
         }
         else {

--- a/rubix-core/pom.xml
+++ b/rubix-core/pom.xml
@@ -28,7 +28,7 @@
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-common</artifactId>
-            <scope>test</scope>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>

--- a/rubix-core/src/test/java/com/qubole/rubix/core/TestCachedReadRequestChain.java
+++ b/rubix-core/src/test/java/com/qubole/rubix/core/TestCachedReadRequestChain.java
@@ -19,6 +19,7 @@ import org.testng.annotations.Test;
 import java.io.File;
 import java.io.IOException;
 import java.io.RandomAccessFile;
+import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 
 import static com.qubole.rubix.core.DataGen.getExpectedOutput;

--- a/rubix-presto/src/main/java/com/qubole/rubix/presto/PrestoClusterManager.java
+++ b/rubix-presto/src/main/java/com/qubole/rubix/presto/PrestoClusterManager.java
@@ -161,12 +161,11 @@ public class PrestoClusterManager extends ClusterManager
                             if (allNodes.isEmpty()) {
                                 // Empty result set => server up and only master node running, return localhost has the only node
                                 // Do not need to consider failed nodes list as 1node cluster and server is up since it replied to allNodesRequest
-                                return ImmutableList.of(InetAddress.getLocalHost().getHostName());
+                                return ImmutableList.of(InetAddress.getLocalHost().getHostAddress());
                             }
 
                             if (failedNodes.isEmpty()) {
                                 failedNodes = ImmutableList.of();
-                                //return ImmutableList.of(InetAddress.getLocalHost().getHostName());
                             }
 
                             // keep only the healthy nodes
@@ -179,7 +178,7 @@ public class PrestoClusterManager extends ClusterManager
                             }
                             if (hosts.isEmpty()) {
                                 // case of master only cluster
-                                hosts.add(InetAddress.getLocalHost().getHostName());
+                                hosts.add(InetAddress.getLocalHost().getHostAddress());
                             }
                             List<String> hostList = Lists.newArrayList(hosts.toArray(new String[0]));
                             Collections.sort(hostList);

--- a/rubix-spi/src/main/java/com/qubole/rubix/spi/CacheConfig.java
+++ b/rubix-spi/src/main/java/com/qubole/rubix/spi/CacheConfig.java
@@ -63,7 +63,8 @@ public class CacheConfig
     private static String localTransferBufferSizeConf = "hadoop.cache.data.buffer.size";
     public static String localServerPortConf = "hadoop.cache.data.local.server.port";
     private static String dataMaxHeaderSizeConf = "hadoop.cache.data.transfer.header.size";
-    private static String diskReadBufferSize = "hadoop.cache.data.disk.read.buffer.size";
+    private static String diskReadBufferSizeConf = "hadoop.cache.data.disk.read.buffer.size";
+    public static String socketReadTimeOutConf = "hadoop.cache.network.socket.read.timeout";
     static String fileCacheDirSuffixConf = "/fcache/";
     static int maxDisksConf = 5;
 
@@ -78,10 +79,20 @@ public class CacheConfig
     private static int localServerPort = 8898;
     private static int serverMaxThreads = Integer.MAX_VALUE;
     public static int localTransferbufferSize = 10 * 1024 * 1024;
-    public static int diskReadBufferSizeDefault = 1024 * 1024;
-
+    public static final int diskReadBufferSizeDefault = 1024;
+    public static int socketReadTimeOutDefault = 30000; // In milliseconds.
     private CacheConfig()
     {
+    }
+
+    public static int getSocketReadTimeOutDefault(Configuration conf)
+    {
+        return conf.getInt(socketReadTimeOutConf, socketReadTimeOutDefault);
+    }
+
+    public static int getDiskReadBufferSizeDefault(Configuration conf)
+    {
+        return conf.getInt(diskReadBufferSizeConf, diskReadBufferSizeDefault);
     }
 
     public static int getCacheDataExpiration(Configuration conf)

--- a/rubix-spi/src/main/java/com/qubole/rubix/spi/CacheConfig.java
+++ b/rubix-spi/src/main/java/com/qubole/rubix/spi/CacheConfig.java
@@ -63,6 +63,7 @@ public class CacheConfig
     private static String localTransferBufferSizeConf = "hadoop.cache.data.buffer.size";
     public static String localServerPortConf = "hadoop.cache.data.local.server.port";
     private static String dataMaxHeaderSizeConf = "hadoop.cache.data.transfer.header.size";
+    private static String diskReadBufferSize = "hadoop.cache.data.disk.read.buffer.size";
     static String fileCacheDirSuffixConf = "/fcache/";
     static int maxDisksConf = 5;
 
@@ -77,6 +78,7 @@ public class CacheConfig
     private static int localServerPort = 8898;
     private static int serverMaxThreads = Integer.MAX_VALUE;
     public static int localTransferbufferSize = 10 * 1024 * 1024;
+    public static int diskReadBufferSizeDefault = 1024 * 1024;
 
     private CacheConfig()
     {

--- a/rubix-spi/src/main/java/com/qubole/rubix/spi/DataTransferClientHelper.java
+++ b/rubix-spi/src/main/java/com/qubole/rubix/spi/DataTransferClientHelper.java
@@ -33,6 +33,7 @@ public class DataTransferClientHelper
     {
         SocketAddress sad = new InetSocketAddress(remoteNodeName, CacheConfig.getLocalServerPort(conf));
         SocketChannel sc = SocketChannel.open();
+        sc.socket().setSoTimeout(CacheConfig.getSocketReadTimeOutDefault(conf));
         sc.configureBlocking(true);
         sc.socket().connect(sad, CacheConfig.getClientTimeout(conf));
         return sc;

--- a/rubix-tests/src/test/java/com/qubole/rubix/tests/TestNonLocalReadRequestChain.java
+++ b/rubix-tests/src/test/java/com/qubole/rubix/tests/TestNonLocalReadRequestChain.java
@@ -50,6 +50,7 @@ public class TestNonLocalReadRequestChain
     File backendFile = new File(backendFileName);
     final Configuration conf = new Configuration();
     Thread localDataTransferServer;
+    Thread bookKeeperServer;
 
     NonLocalReadRequestChain nonLocalReadRequestChain;
     private static final Log log = LogFactory.getLog(TestNonLocalReadRequestChain.class);
@@ -63,6 +64,14 @@ public class TestNonLocalReadRequestChain
         conf.setInt(CacheConfig.localServerPortConf, 2222);
         conf.setInt(CacheConfig.blockSizeConf, blockSize);
         conf.set("hadoop.cache.data.dirprefix.list", "/tmp/ephemeral");
+        bookKeeperServer = new Thread()
+        {
+            public void run()
+            {
+                BookKeeperServer.startServer(conf);
+            }
+        };
+
         localDataTransferServer = new Thread()
         {
             public void run()
@@ -70,19 +79,22 @@ public class TestNonLocalReadRequestChain
                 LocalDataTransferServer.startServer(conf);
             }
         };
-        Thread thread = new Thread()
-        {
-            public void run()
-            {
-                BookKeeperServer.startServer(conf);
-            }
-        };
-        thread.start();
+
+        bookKeeperServer.start();
+        localDataTransferServer.start();
+
 
         while (!BookKeeperServer.isServerUp()) {
             Thread.sleep(200);
             log.info("Waiting for BookKeeper Server to come up");
         }
+        log.info("BookKepper Server started");
+
+        while (!LocalDataTransferServer.isServerUp()) {
+            Thread.sleep(200);
+            log.info("Waiting for Local Data Transfer Server to come up");
+        }
+        log.info("Local Data Transfer Server started");
 
         // Populate File
         DataGen.populateFile(backendFileName);
@@ -98,13 +110,21 @@ public class TestNonLocalReadRequestChain
     private void testRemoteRead()
             throws Exception
     {
-        localDataTransferServer.start();
-        while (!LocalDataTransferServer.isServerUp()) {
-            Thread.sleep(200);
-            log.info("Waiting for Local Data Transfer Server to come up");
-        }
-        nonLocalReadRequestChain.strictMode = true;
+         nonLocalReadRequestChain.strictMode = true;
         test();
+    }
+
+    @Test
+    private void testSocketReadTimeOut()
+            throws Exception
+    {
+        nonLocalReadRequestChain.strictMode = false;
+        //Set timeout to a very low value ex: 10ms.
+        conf.setInt(CacheConfig.socketReadTimeOutConf, 10);
+        test();
+        //Verify whether "socket read timed out. Using direct reads" is present in output.
+        //Expected to read 0 bytes via non local reads and 350 bytes via direct read.
+        //TODO: Change test method and add proper unit tests in future.
     }
 
     @Test
@@ -119,15 +139,12 @@ public class TestNonLocalReadRequestChain
     private void testDirectRead2()
             throws Exception
     {
-        localDataTransferServer.start();
         BookKeeperServer.stopServer();
-        while (!LocalDataTransferServer.isServerUp()) {
-            Thread.sleep(200);
-            log.info("Waiting for Local Data Transfer Server to come up");
-        }
         nonLocalReadRequestChain.strictMode = false;
         test();
     }
+
+
 
     public void test()
             throws Exception


### PR DESCRIPTION
Added timeout functionality to NonLocalReadRequestChain reads to ensure that we dont wait indefinitely. The value can be configured with 'hadoop.cache.network.socket.read.timeout' parameter, default is 30000ms. 
Did basic unit testing to verify the change.