### PR TITLE
Socket to

### DIFF
--- a/rubix-bookkeeper/src/main/java/com/qubole/rubix/bookkeeper/BookKeeper.java
+++ b/rubix-bookkeeper/src/main/java/com/qubole/rubix/bookkeeper/BookKeeper.java
@@ -191,19 +191,19 @@ public class BookKeeper
                         clusterManager.initialize(conf);
                         // set the global clusterManager only after it is inited
                         this.clusterManager = clusterManager;
-                        nodes = clusterManager.getNodes();
                         splitSize = clusterManager.getSplitSize();
-                        currentNodeIndex = nodes.indexOf(nodeName);
                     }
                 }
             }
-            if (nodes == null || nodes.size() == 0 || currentNodeIndex == -1) {
-                log.error(String.format("Could not initialize cluster nodes=%s nodeName=%s currentNodeIndex=%d", nodes, nodeName, currentNodeIndex));
-            }
+
         }
 
         nodes = clusterManager.getNodes();
         currentNodeIndex = nodes.indexOf(nodeName);
+        if (nodes == null || nodes.size() == 0 || currentNodeIndex == -1) {
+            log.error(String.format("Could not initialize cluster nodes=%s nodeName=%s currentNodeIndex=%d", nodes, nodeName, currentNodeIndex));
+            // mark clusterManager null so that some
+        }
     }
 
     @Override

--- a/rubix-bookkeeper/src/main/java/com/qubole/rubix/bookkeeper/BookKeeper.java
+++ b/rubix-bookkeeper/src/main/java/com/qubole/rubix/bookkeeper/BookKeeper.java
@@ -28,6 +28,7 @@ import com.qubole.rubix.core.RemoteReadRequestChain;
 import com.qubole.rubix.hadoop2.Hadoop2ClusterManager;
 import com.qubole.rubix.presto.PrestoClusterManager;
 import com.qubole.rubix.spi.BlockLocation;
+import com.qubole.rubix.spi.BookKeeperFactory;
 import com.qubole.rubix.spi.CacheConfig;
 import com.qubole.rubix.spi.ClusterManager;
 import com.qubole.rubix.spi.ClusterType;
@@ -139,7 +140,7 @@ public class BookKeeper
                 cachedRequests++;
             }
             else {
-                if (blockSplits.get(split).equalsIgnoreCase(nodes.get(currentNodeIndex))) {
+                if (blockSplits.get(split).equalsIgnoreCase(nodeName)) {
                     blockLocations.add(new BlockLocation(Location.LOCAL, blockSplits.get(split)));
                     remoteRequests++;
                 }
@@ -286,7 +287,7 @@ public class BookKeeper
                     // Cache the data
                     // Ue RRRC directly instead of creating instance of CachingFS as in certain circumstances, CachingFS could
                     // send this request to NonLocalRRC which would be wrong as that would not cache it on disk
-                    RemoteReadRequestChain remoteReadRequestChain = new RemoteReadRequestChain(inputStream, localPath, byteBuffer, buffer);
+                    RemoteReadRequestChain remoteReadRequestChain = new RemoteReadRequestChain(inputStream, localPath, byteBuffer, buffer, new BookKeeperFactory(this));
                     remoteReadRequestChain.addReadRequest(new ReadRequest(readStart, readStart + blockSize, readStart, readStart + blockSize, buffer, 0, fileSize));
                     remoteReadRequestChain.lock();
                     remoteReadRequestChain.call();

--- a/rubix-bookkeeper/src/main/java/com/qubole/rubix/bookkeeper/LocalDataTransferServer.java
+++ b/rubix-bookkeeper/src/main/java/com/qubole/rubix/bookkeeper/LocalDataTransferServer.java
@@ -158,7 +158,7 @@ public class LocalDataTransferServer
                 long offset = header.getOffset();
                 int readLength = header.getReadLength();
                 String remotePath = header.getFilePath();
-
+                log.debug(String.format("Trying to read from %s at offset %d and length %d for client %s", remotePath, offset, readLength, localDataTransferClient.getRemoteAddress()));
                 try {
                     this.bookKeeperClient = bookKeeperFactory.createBookKeeperClient(conf);
                 }
@@ -191,10 +191,11 @@ public class LocalDataTransferServer
                     bookKeeperClient.close();
                 }
                 fc.close();
+                log.debug(String.format("Done reading %d from %s at offset %d and length %d for client %s", nread, remotePath, offset, readLength, localDataTransferClient.getRemoteAddress()));
             }
             catch (Exception e) {
                 try {
-                    log.warn("Error in Local Data Transfer Server for client: " + localDataTransferClient.getLocalAddress(), e);
+                    log.warn("Error in Local Data Transfer Server for client: " + localDataTransferClient.getRemoteAddress(), e);
                 }
                 catch (IOException e1) {
                     log.warn("Error in Local Data Transfer Server for client: ", e);

--- a/rubix-core/src/main/java/com/qubole/rubix/core/CachingInputStream.java
+++ b/rubix-core/src/main/java/com/qubole/rubix/core/CachingInputStream.java
@@ -176,6 +176,18 @@ public class CachingInputStream
     public int read(byte[] buffer, int offset, int length)
             throws IOException
     {
+        try {
+            return readInternal(buffer, offset, length);
+        }
+        catch (Exception e) {
+            log.error(String.format("Failed to read from rubix for file %s position %d length %d. Falling back to remote", localPath, nextReadPosition, length), e);
+            inputStream.seek(nextReadPosition);
+            return inputStream.read(buffer, offset, length);
+        }
+    }
+
+    private int readInternal(byte[] buffer, int offset, int length)
+    {
         log.debug(String.format("Got Read, currentPos: %d currentBlock: %d bufferOffset: %d length: %d", nextReadPosition, nextReadBlock, offset, length));
 
         if (nextReadPosition >= fileSize) {

--- a/rubix-core/src/test/java/com/qubole/rubix/core/TestRemoteReadRequestChain.java
+++ b/rubix-core/src/test/java/com/qubole/rubix/core/TestRemoteReadRequestChain.java
@@ -22,7 +22,6 @@ import org.testng.annotations.Test;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
-import java.io.RandomAccessFile;
 import java.nio.charset.Charset;
 
 import static org.testng.AssertJUnit.assertTrue;
@@ -40,7 +39,6 @@ public class TestRemoteReadRequestChain
     String localFileName = "/tmp/testRemoteReadRequestChainLocalFile";
 
     RemoteReadRequestChain remoteReadRequestChain;
-    RandomAccessFile randomAccessFile;
 
     private static final Log log = LogFactory.getLog(TestRemoteReadRequestChain.class);
 
@@ -53,9 +51,8 @@ public class TestRemoteReadRequestChain
 
         LocalFSInputStream localFSInputStream = new LocalFSInputStream(backendFileName);
         fsDataInputStream = new FSDataInputStream(localFSInputStream);
-        randomAccessFile = new RandomAccessFile(localFileName,"rw");
 
-        remoteReadRequestChain = new RemoteReadRequestChain(fsDataInputStream, randomAccessFile);
+        remoteReadRequestChain = new RemoteReadRequestChain(fsDataInputStream, localFileName);
     }
 
     @Test
@@ -164,7 +161,6 @@ public class TestRemoteReadRequestChain
             throws IOException
     {
         fsDataInputStream.close();
-        randomAccessFile.close();
         backendFile.delete();
         File localFile = new File(localFileName);
         localFile.delete();

--- a/rubix-spi/src/main/java/com/qubole/rubix/spi/CacheConfig.java
+++ b/rubix-spi/src/main/java/com/qubole/rubix/spi/CacheConfig.java
@@ -64,6 +64,7 @@ public class CacheConfig
     public static String localServerPortConf = "hadoop.cache.data.local.server.port";
     private static String dataMaxHeaderSizeConf = "hadoop.cache.data.transfer.header.size";
     private static String diskReadBufferSizeConf = "hadoop.cache.data.disk.read.buffer.size";
+    public static String socketReadTimeOutConf = "hadoop.cache.network.socket.read.timeout";
     static String fileCacheDirSuffixConf = "/fcache/";
     static int maxDisksConf = 5;
 
@@ -79,9 +80,14 @@ public class CacheConfig
     private static int serverMaxThreads = Integer.MAX_VALUE;
     public static int localTransferbufferSize = 10 * 1024 * 1024;
     public static final int diskReadBufferSizeDefault = 1024;
-
+    public static int socketReadTimeOutDefault = 30000; // In milliseconds.
     private CacheConfig()
     {
+    }
+
+    public static int getSocketReadTimeOutDefault(Configuration conf)
+    {
+        return conf.getInt(socketReadTimeOutConf, socketReadTimeOutDefault);
     }
 
     public static int getDiskReadBufferSizeDefault(Configuration conf)

--- a/rubix-spi/src/main/java/com/qubole/rubix/spi/ClusterManager.java
+++ b/rubix-spi/src/main/java/com/qubole/rubix/spi/ClusterManager.java
@@ -29,7 +29,7 @@ public abstract class ClusterManager
 {
     private long splitSize = 256 * 1024 * 1024; // 256MB
 
-    private int nodeRefreshTime = 10; //sec
+    private int nodeRefreshTime = 300; //sec
 
     public static String splitSizeConf = "caching.fs.split-size";
 

--- a/rubix-spi/src/main/java/com/qubole/rubix/spi/DataTransferClientHelper.java
+++ b/rubix-spi/src/main/java/com/qubole/rubix/spi/DataTransferClientHelper.java
@@ -33,6 +33,7 @@ public class DataTransferClientHelper
     {
         SocketAddress sad = new InetSocketAddress(remoteNodeName, CacheConfig.getLocalServerPort(conf));
         SocketChannel sc = SocketChannel.open();
+        sc.socket().setSoTimeout(CacheConfig.getSocketReadTimeOutDefault(conf));
         sc.configureBlocking(true);
         sc.socket().connect(sad, CacheConfig.getClientTimeout(conf));
         return sc;

--- a/rubix-spi/src/main/java/com/qubole/rubix/spi/LocalBookKeeperClient.java
+++ b/rubix-spi/src/main/java/com/qubole/rubix/spi/LocalBookKeeperClient.java
@@ -43,6 +43,13 @@ public class LocalBookKeeperClient
     }
 
     @Override
+    public void setAllCached(final String remotePath, final long fileLength, final long lastModified, final long startBlock, final long endBlock)
+            throws TException
+    {
+        bookKeeper.setAllCached(remotePath, fileLength, lastModified, startBlock, endBlock);
+    }
+
+    @Override
     public void close()
             throws IOException
     {

--- a/rubix-tests/src/test/java/com/qubole/rubix/tests/TestNonLocalReadRequestChain.java
+++ b/rubix-tests/src/test/java/com/qubole/rubix/tests/TestNonLocalReadRequestChain.java
@@ -50,6 +50,7 @@ public class TestNonLocalReadRequestChain
     File backendFile = new File(backendFileName);
     final Configuration conf = new Configuration();
     Thread localDataTransferServer;
+    Thread bookKeeperServer;
 
     NonLocalReadRequestChain nonLocalReadRequestChain;
     private static final Log log = LogFactory.getLog(TestNonLocalReadRequestChain.class);
@@ -63,6 +64,14 @@ public class TestNonLocalReadRequestChain
         conf.setInt(CacheConfig.localServerPortConf, 2222);
         conf.setInt(CacheConfig.blockSizeConf, blockSize);
         conf.set("hadoop.cache.data.dirprefix.list", "/tmp/ephemeral");
+        bookKeeperServer = new Thread()
+        {
+            public void run()
+            {
+                BookKeeperServer.startServer(conf);
+            }
+        };
+
         localDataTransferServer = new Thread()
         {
             public void run()
@@ -70,19 +79,22 @@ public class TestNonLocalReadRequestChain
                 LocalDataTransferServer.startServer(conf);
             }
         };
-        Thread thread = new Thread()
-        {
-            public void run()
-            {
-                BookKeeperServer.startServer(conf);
-            }
-        };
-        thread.start();
+
+        bookKeeperServer.start();
+        localDataTransferServer.start();
+
 
         while (!BookKeeperServer.isServerUp()) {
             Thread.sleep(200);
             log.info("Waiting for BookKeeper Server to come up");
         }
+        log.info("BookKepper Server started");
+
+        while (!LocalDataTransferServer.isServerUp()) {
+            Thread.sleep(200);
+            log.info("Waiting for Local Data Transfer Server to come up");
+        }
+        log.info("Local Data Transfer Server started");
 
         // Populate File
         DataGen.populateFile(backendFileName);
@@ -98,13 +110,21 @@ public class TestNonLocalReadRequestChain
     private void testRemoteRead()
             throws Exception
     {
-        localDataTransferServer.start();
-        while (!LocalDataTransferServer.isServerUp()) {
-            Thread.sleep(200);
-            log.info("Waiting for Local Data Transfer Server to come up");
-        }
-        nonLocalReadRequestChain.strictMode = true;
+         nonLocalReadRequestChain.strictMode = true;
         test();
+    }
+
+    @Test
+    private void testSocketReadTimeOut()
+            throws Exception
+    {
+        nonLocalReadRequestChain.strictMode = false;
+        //Set timeout to a very low value ex: 10ms.
+        conf.setInt(CacheConfig.socketReadTimeOutConf, 10);
+        test();
+        //Verify whether "socket read timed out. Using direct reads" is present in output.
+        //Expected to read 0 bytes via non local reads and 350 bytes via direct read.
+        //TODO: Change test method and add proper unit tests in future.
     }
 
     @Test
@@ -119,15 +139,12 @@ public class TestNonLocalReadRequestChain
     private void testDirectRead2()
             throws Exception
     {
-        localDataTransferServer.start();
         BookKeeperServer.stopServer();
-        while (!LocalDataTransferServer.isServerUp()) {
-            Thread.sleep(200);
-            log.info("Waiting for Local Data Transfer Server to come up");
-        }
         nonLocalReadRequestChain.strictMode = false;
         test();
     }
+
+
 
     public void test()
             throws Exception


### PR DESCRIPTION
* vamshi's socket timeout fix
* RandomAccessFile per RRRC, current model was leading to Illegal Seek exceptions
* Corrections in log
* Harden read() method to fall back to direct read
* Socket Timeouts were happening due to NativeS3FileSystem threads waiting on ConnectionPool. We had seen this before in Presto and disabled nativeS3FileSystem cache had helped. It helps here too. Those changes are in the script that starts bookkeeper so not part of this PR