### PR TITLE
Added DiskMonitor service

### DIFF
--- a/rubix-bookkeeper/src/main/java/com/qubole/rubix/bookkeeper/BookKeeperServer.java
+++ b/rubix-bookkeeper/src/main/java/com/qubole/rubix/bookkeeper/BookKeeperServer.java
@@ -60,6 +60,8 @@ public class BookKeeperServer
     public static void startServer(Configuration conf)
     {
         bookKeeper = new BookKeeper(conf);
+        DiskMonitorService diskMonitorService = new DiskMonitorService(conf, bookKeeper);
+        diskMonitorService.startAsync();
         processor = new BookKeeperService.Processor(bookKeeper);
         log.info("Starting BookKeeperServer on port " + getServerPort(conf));
         try {

--- a/rubix-bookkeeper/src/main/java/com/qubole/rubix/bookkeeper/DiskMonitorService.java
+++ b/rubix-bookkeeper/src/main/java/com/qubole/rubix/bookkeeper/DiskMonitorService.java
@@ -1,0 +1,156 @@
+/**
+ * Copyright (c) 2016. Qubole Inc
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License. See accompanying LICENSE file.
+ */
+package com.qubole.rubix.bookkeeper;
+
+import com.google.common.base.Throwables;
+import com.google.common.cache.Cache;
+import com.google.common.cache.RemovalCause;
+import com.google.common.util.concurrent.AbstractScheduledService;
+import com.qubole.rubix.spi.CacheConfig;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.hadoop.conf.Configuration;
+
+import java.io.IOException;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import static com.qubole.rubix.bookkeeper.utils.DiskUtils.getUsedSpaceMB;
+
+/**
+ * Created by shubham on 19/05/17.
+ */
+public class DiskMonitorService extends AbstractScheduledService
+{
+    private Executor executor = Executors.newSingleThreadExecutor();
+    private final int interval;
+    private final BookKeeper bookKeeper;
+
+    private static Log log = LogFactory.getLog(DiskMonitorService.class.getName());
+
+    private static final Callable METADATA_LOADER = new CreateDiskUsageFileMetadataCallable();
+    private static final FileMetadata DISK_USAGE_ENTRY = new DiskUsageFileMetada();
+    private static final String DISK_USAGE_KEY = "DISK_USAGE_KEY";
+
+    @Override
+    protected void runOneIteration() throws Exception
+    {
+        try {
+            bookKeeper.invalidateEntry(DISK_USAGE_KEY);
+            bookKeeper.getEntry(DISK_USAGE_KEY, METADATA_LOADER);
+        }
+        catch (ExecutionException e) {
+            log.error("Could not refresh disk usage", e);
+        }
+    }
+
+    public DiskMonitorService(Configuration configuration, BookKeeper bookKeeper)
+    {
+        interval = CacheConfig.getDiskMonitorInterval(configuration);
+        this.bookKeeper = bookKeeper;
+    }
+
+    @Override
+    protected Scheduler scheduler()
+    {
+        return Scheduler.newFixedDelaySchedule(60, interval, TimeUnit.SECONDS);
+    }
+
+    static class FailureListener extends com.google.common.util.concurrent.Service.Listener
+    {
+        @Override
+        public void failed(State from, Throwable failure)
+        {
+            super.failed(from, failure);
+            log.error("hit a problem " + Throwables.getStackTraceAsString(failure));
+        }
+    }
+
+    @Override
+    protected void startUp()
+    {
+        log.info("starting service " + serviceName() + " in thread " + Thread.currentThread().getId());
+        addListener(new FailureListener(), executor);
+    }
+
+    private static class DiskUsageFileMetada extends FileMetadata
+    {
+        @Override
+        public void closeAndCleanup(RemovalCause cause, Cache cache)
+                throws IOException
+        {
+            log.info("Removing  disk_usage_entry due to " + cause);
+            return;
+        }
+
+        @Override
+        public int getWeight(Configuration conf)
+        {
+            /*
+             * Following new logic for evictions:
+             *  All FileMetada entries have weight = 0
+             *  There is a special entry DISK_USAGE_ENTRY which maps to the amount of space used on disk
+             *  This entry is updated periodically by a daemon
+             *  Evictions due to disk space exhaustion are driven by this entry
+             *  Since guava cache evicts LRU based and not weighted, actual entries will get removed
+             */
+            int weight = getUsedSpaceMB(conf);
+            log.info("UsedSpace " + weight);
+            return weight;
+        }
+
+        // Methods below should not be called on this class
+        @Override
+        public boolean isBlockCached(long blockNumber)
+        {
+            throw new UnsupportedOperationException("Got a isBLockCached request for Disk_Usage FileMetadata entry ");
+        }
+
+        @Override
+        public void setBlockCached(long blockNumber)
+        {
+            throw new UnsupportedOperationException("Got a setBLockCached request for Disk_Usage FileMetadata entry ");
+        }
+
+        @Override
+        public long getLastModified()
+        {
+            throw new UnsupportedOperationException("Got a getLastModified request for Disk_Usage FileMetadata entry ");
+        }
+
+        @Override
+        public String getMdFilePath()
+        {
+            throw new UnsupportedOperationException("Got a getMdFilePath request for Disk_Usage FileMetadata entry ");
+        }
+
+        @Override
+        public String getRemotePath()
+        {
+            throw new UnsupportedOperationException("Got a getRemotePath request for Disk_Usage FileMetadata entry ");
+        }
+    }
+
+    private static class CreateDiskUsageFileMetadataCallable
+            implements Callable<FileMetadata>
+    {
+        @Override
+        public FileMetadata call() throws Exception
+        {
+            return DISK_USAGE_ENTRY;
+        }
+    }
+}

--- a/rubix-bookkeeper/src/main/java/com/qubole/rubix/bookkeeper/utils/DiskUtils.java
+++ b/rubix-bookkeeper/src/main/java/com/qubole/rubix/bookkeeper/utils/DiskUtils.java
@@ -12,6 +12,7 @@
  */
 package com.qubole.rubix.bookkeeper.utils;
 
+import com.qubole.rubix.spi.CacheConfig;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -41,5 +42,15 @@ public class DiskUtils
         ShellExec.CommandResult cr = se.runCmd();
         long size = Long.parseLong(cr.getOut().trim());
         return size * 1024;
+    }
+
+    public static int getUsedSpaceMB(org.apache.hadoop.conf.Configuration conf)
+    {
+        long used = 0;
+        for (int d = 0; d < CacheConfig.numDisks(conf); d++) {
+            File localPath = new File(CacheConfig.getDirPath(conf, d));
+            used += localPath.getTotalSpace() - localPath.getUsableSpace();
+        }
+        return (int) (used / 1024 / 1024);
     }
 }

--- a/rubix-spi/src/main/java/com/qubole/rubix/spi/CacheConfig.java
+++ b/rubix-spi/src/main/java/com/qubole/rubix/spi/CacheConfig.java
@@ -65,13 +65,14 @@ public class CacheConfig
     private static String dataMaxHeaderSizeConf = "hadoop.cache.data.transfer.header.size";
     private static String diskReadBufferSizeConf = "hadoop.cache.data.disk.read.buffer.size";
     public static String socketReadTimeOutConf = "hadoop.cache.network.socket.read.timeout";
+    private static String diskMonitorIntervalConf = "hadoop.cache.disk.monitor.interval";
     static String fileCacheDirSuffixConf = "/fcache/";
     static int maxDisksConf = 5;
 
     // default values
     private static final int dataCacheExpiry = Integer.MAX_VALUE;
     // Keepnig this low to workaround the Guava Cache static weighing limitation
-    private static final int dataCacheExpiryAfterWrite = 30; //In sec
+    private static final int dataCacheExpiryAfterWrite = Integer.MAX_VALUE; // In seconds, inifinite by default
     private static final int dataCacheFullness = 80; // percent
     private static final String dataCacheDirPrefixes = "/media/ephemeral";
     private static final int blockSize = 1 * 1024 * 1024; // 1MB
@@ -81,6 +82,8 @@ public class CacheConfig
     public static int localTransferbufferSize = 10 * 1024 * 1024;
     public static final int diskReadBufferSizeDefault = 1024;
     public static int socketReadTimeOutDefault = 30000; // In milliseconds.
+    private static int diskMonitorInterval = 10; // in seconds
+
     private CacheConfig()
     {
     }
@@ -372,5 +375,10 @@ public class CacheConfig
     public static int getMaxHeaderSize(Configuration conf)
     {
         return conf.getInt(dataMaxHeaderSizeConf, 1024);
+    }
+
+    public static int getDiskMonitorInterval(Configuration conf)
+    {
+        return conf.getInt(diskMonitorIntervalConf, diskMonitorInterval);
     }
 }


### PR DESCRIPTION
This service is responsible to add an entry in cache which denotes the total disk used up.
Only this entry has non-zero weight in the cache and once the weight of this entry comes
close to cache max-weight, evictions would start.

This benefits us over the old approach of aggressive invalidations of cache entries and re-entries
with the size occupied on disk at that time by lowering the amount of work as invalidation are much
fewer now.
Also, the shift towards executing the old approach in new thread had lead to explosion of threads
slowing down the service.