### PR TITLE
new:dev: Upgrade thrift & maven-thrift-plugin. Make tests relocatable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,23 @@
+# Compiled class file
+*.class
+#
+# # Log file
+*.log
+#
+# # Package Files #
+*.jar
+*.war
+*.ear
+*.zip
+*.tar.gz
+*.rar
+
+# # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+# hs_err_pid*
+#
+# IntelliJ files
+.idea/*
+*.iml
+
+# Maven
+target

--- a/README.md
+++ b/README.md
@@ -81,9 +81,21 @@ presto:default> select * from jmx.jmx."rubix:name=stats";
 
 ### Building
 
-mvn clean install
+#### Setup Thrift
+Note that you will need thrift-0.9.3 installed
 
-> Note that you will need thrift-0.9.0 installed
+    # Mac OS X/Brew instructions
+    
+    ## Installs thrift 0.10.0
+    brew install thrift
+    
+    ### Install thrift 0.9.3
+    brew unlink thrift
+    brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/9d524e4850651cfedd64bc0740f1379b533f607d/Formula/thrift.rb
+
+#### Compile and install
+    mvn clean install
+
 
 ### Need Help?
 You can post your queries to https://groups.google.com/forum/#!forum/rubix-users

--- a/rubix-bookkeeper/src/main/java/com/qubole/rubix/bookkeeper/LocalDataTransferServer.java
+++ b/rubix-bookkeeper/src/main/java/com/qubole/rubix/bookkeeper/LocalDataTransferServer.java
@@ -106,7 +106,8 @@ public class LocalDataTransferServer
                 log.info("Stopping Local Transfer server");
             }
             catch (IOException e) {
-                log.error(String.format("Error starting Local Transfer server %s", e));
+                log.error(String.format("Error starting Local Transfer server %s", e), e);
+                e.printStackTrace();
             }
 
         }

--- a/rubix-bookkeeper/src/main/java/com/qubole/rubix/bookkeeper/LocalDataTransferServer.java
+++ b/rubix-bookkeeper/src/main/java/com/qubole/rubix/bookkeeper/LocalDataTransferServer.java
@@ -106,8 +106,7 @@ public class LocalDataTransferServer
                 log.info("Stopping Local Transfer server");
             }
             catch (IOException e) {
-                log.error(String.format("Error starting Local Transfer server %s", e), e);
-                e.printStackTrace();
+                log.error(String.format("Error starting Local Transfer server %s", e));
             }
 
         }

--- a/rubix-spi/pom.xml
+++ b/rubix-spi/pom.xml
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>org.apache.thrift</groupId>
             <artifactId>libthrift</artifactId>
-            <version>0.9.2</version>
+            <version>0.9.3</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>
@@ -74,9 +74,10 @@
             <plugin>
                 <groupId>org.apache.thrift.tools</groupId>
                 <artifactId>maven-thrift-plugin</artifactId>
-                <version>0.1.10</version>
+                <version>0.1.11</version>
                 <configuration>
                     <thriftExecutable>/usr/local/bin/thrift</thriftExecutable>
+                    <generator>java</generator>
                 </configuration>
                 <executions>
                     <execution>
@@ -102,7 +103,7 @@
                         <configuration>
                             <artifactSet>
                                 <includes>
-                                    -<include>org.apache.thrift:libthrift</include>
+                                    <include>org.apache.thrift:libthrift</include>
                                     <include>com.google.guava:guava</include>
                                 </includes>
                             </artifactSet>
@@ -123,10 +124,4 @@
             </plugin>
         </plugins>
     </build>
-    <pluginRepositories>
-        <pluginRepository>
-            <id>dtrott</id>
-            <url>http://maven.davidtrott.com/repository</url>
-        </pluginRepository>
-    </pluginRepositories>
 </project>

--- a/rubix-spi/src/main/java/com/qubole/rubix/spi/CacheConfig.java
+++ b/rubix-spi/src/main/java/com/qubole/rubix/spi/CacheConfig.java
@@ -18,6 +18,8 @@ import com.google.common.base.Suppliers;
 import com.google.common.hash.HashCode;
 import com.google.common.hash.HashFunction;
 import com.google.common.hash.Hashing;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 
@@ -83,6 +85,8 @@ public class CacheConfig
     public static final int diskReadBufferSizeDefault = 1024;
     public static int socketReadTimeOutDefault = 30000; // In milliseconds.
     private static int diskMonitorInterval = 10; // in seconds
+
+    private static final Log log = LogFactory.getLog(CacheConfig.class.getName());
 
     private CacheConfig()
     {
@@ -160,6 +164,7 @@ public class CacheConfig
                 List<String> dirPrefixList = getDirPrefixList(conf);
                 for (String dirPrefix : dirPrefixList) {
                     for (int i = 0; i < maxDisksConf; ++i) {
+                        log.info("Checking " + dirPrefix + i);
                         if (exists(dirPrefix + i)) {
                             File dir = new File(dirPrefix + i + fileCacheDirSuffixConf);
                             dir.mkdir();

--- a/rubix-spi/src/main/java/com/qubole/rubix/spi/CacheConfig.java
+++ b/rubix-spi/src/main/java/com/qubole/rubix/spi/CacheConfig.java
@@ -164,7 +164,7 @@ public class CacheConfig
                 List<String> dirPrefixList = getDirPrefixList(conf);
                 for (String dirPrefix : dirPrefixList) {
                     for (int i = 0; i < maxDisksConf; ++i) {
-                        log.info("Checking " + dirPrefix + i);
+                        log.debug("Checking " + dirPrefix + i);
                         if (exists(dirPrefix + i)) {
                             File dir = new File(dirPrefix + i + fileCacheDirSuffixConf);
                             dir.mkdir();

--- a/rubix-tests/pom.xml
+++ b/rubix-tests/pom.xml
@@ -77,6 +77,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
+                    <workingDirectory>${project.build.testOutputDirectory}</workingDirectory>
                     <systemPropertyVariables>
                         <log4j.configuration>file:${project.build.testOutputDirectory}/log4j-surefire.properties</log4j.configuration>
                     </systemPropertyVariables>

--- a/rubix-tests/src/test/java/com/qubole/rubix/tests/DeleteFileVisitor.java
+++ b/rubix-tests/src/test/java/com/qubole/rubix/tests/DeleteFileVisitor.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) 2016. Qubole Inc
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License. See accompanying LICENSE file.
+ */
+
+package com.qubole.rubix.tests;
+
+import java.io.IOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+
+/**
+ * Created by rvenkatesh on 7/17/17.
+ */
+class DeleteFileVisitor extends SimpleFileVisitor<Path> {
+  @Override
+  public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+    Files.delete(file);
+    return FileVisitResult.CONTINUE;
+  }
+
+  @Override
+  public FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
+    Files.delete(dir);
+    return FileVisitResult.CONTINUE;
+  }
+}

--- a/rubix-tests/src/test/java/com/qubole/rubix/tests/TestCachingInputStream.java
+++ b/rubix-tests/src/test/java/com/qubole/rubix/tests/TestCachingInputStream.java
@@ -27,7 +27,11 @@ import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.Path;
-import org.testng.annotations.*;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
 
 
 import java.io.File;

--- a/rubix-tests/src/test/java/com/qubole/rubix/tests/TestNonLocalReadRequestChain.java
+++ b/rubix-tests/src/test/java/com/qubole/rubix/tests/TestNonLocalReadRequestChain.java
@@ -32,7 +32,11 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
-import org.testng.annotations.*;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
 
 import java.io.File;
 import java.io.IOException;


### PR DESCRIPTION
Upgraded thrift from 0.9.0 to 0.9.3. The main motivation is that
0.9.3 can be installed through brew on mac. I tried to upgrade to
thrift 0.10.0 but there were test failures.

Upgrade maven-thrift-plugin to 0.1.11. 0.1.10 is not available anymore
in http://maven.davidtrott.com/repository. 0.1.11 is available in apache
maven repository.
   
Another improvement is that tests assumed specific directory
structures internal to Qubole. The test directories are now
configured relative to `java.io.tmpdir`.