### PR TITLE
Lazy loading of FSDataInputStream

### DIFF
--- a/rubix-core/src/main/java/com/qubole/rubix/core/CachingFileSystem.java
+++ b/rubix-core/src/main/java/com/qubole/rubix/core/CachingFileSystem.java
@@ -115,17 +115,18 @@ public abstract class CachingFileSystem<T extends FileSystem> extends FileSystem
     public FSDataInputStream open(Path path, int bufferSize)
             throws IOException
     {
-        FSDataInputStream inputStream = fs.open(path, bufferSize);
+        FSDataInputStream inputStream = null;
 
         if (skipCache(path, getConf())) {
+            inputStream = fs.open(path, bufferSize);
             cacheSkipped = true;
             return inputStream;
         }
 
         return new FSDataInputStream(
                 new BufferedFSInputStream(
-                        new CachingInputStream(inputStream, this, path, this.getConf(), statsMBean,
-                                clusterManager.getClusterType(), bookKeeperFactory, fs),
+                        new CachingInputStream(this, path, this.getConf(), statsMBean,
+                                clusterManager.getClusterType(), bookKeeperFactory, fs, bufferSize),
                                                     CacheConfig.getBlockSize(getConf())));
     }
 

--- a/rubix-core/src/test/java/com/qubole/rubix/core/MockCachingFileSystem.java
+++ b/rubix-core/src/test/java/com/qubole/rubix/core/MockCachingFileSystem.java
@@ -54,9 +54,10 @@ public class MockCachingFileSystem
         LocalFSInputStream inputStream = new LocalFSInputStream(localPath);
         return new FSDataInputStream(
                 new BufferedFSInputStream(
-                        new CachingInputStream(new FSDataInputStream(inputStream), conf, path, file.length(), file.lastModified(),  new CachingFileSystemStats(),
-                                ClusterType.TEST_CLUSTER_MANAGER, bookKeeperFactory, this),
-                        CacheConfig.getBlockSize(conf)));
+                        new CachingInputStream(new FSDataInputStream(inputStream), conf, path, file.length(),
+                            file.lastModified(),  new CachingFileSystemStats(),
+                            ClusterType.TEST_CLUSTER_MANAGER, bookKeeperFactory, this),
+                    CacheConfig.getBlockSize(conf)));
     }
 
     @Override

--- a/rubix-tests/src/test/java/com/qubole/rubix/tests/TestCachingInputStream.java
+++ b/rubix-tests/src/test/java/com/qubole/rubix/tests/TestCachingInputStream.java
@@ -22,6 +22,7 @@ import com.qubole.rubix.spi.CacheConfig;
 import com.qubole.rubix.bookkeeper.BookKeeperServer;
 import com.qubole.rubix.spi.ClusterType;
 
+
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.conf.Configuration;
@@ -125,7 +126,9 @@ public class TestCachingInputStream
         FSDataInputStream fsDataInputStream = new FSDataInputStream(localFSInputStream);
         conf.setInt(CacheConfig.blockSizeConf, blockSize);
         // This should be after server comes up else client could not be created
-        inputStream = new CachingInputStream(fsDataInputStream, conf, backendPath, file.length(),file.lastModified(), new CachingFileSystemStats(), ClusterType.TEST_CLUSTER_MANAGER, new BookKeeperFactory(), null);
+        inputStream = new CachingInputStream(fsDataInputStream, conf, backendPath, file.length(),
+            file.lastModified(), new CachingFileSystemStats(), ClusterType.TEST_CLUSTER_MANAGER,
+            new BookKeeperFactory(), null);
 
     }
 

--- a/rubix-tests/src/test/java/com/qubole/rubix/tests/TestCachingInputStream.java
+++ b/rubix-tests/src/test/java/com/qubole/rubix/tests/TestCachingInputStream.java
@@ -22,7 +22,6 @@ import com.qubole.rubix.spi.CacheConfig;
 import com.qubole.rubix.bookkeeper.BookKeeperServer;
 import com.qubole.rubix.spi.ClusterType;
 
-
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.conf.Configuration;


### PR DESCRIPTION
Instead of creating a new instance of FSDataInputStream, we are instantiating it only when we needed.