### PR TITLE
new:usr:Add a new module to generate rpm for rubix

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,9 @@ Note that you will need thrift-0.9.3 installed
 #### Compile and install
     mvn clean install
 
-
+#### Generate RPM
+    mvn clean package -Prpm,default
+    
+RPM is created in _rubix-rpm/target/rpm/qubole-rubix/RPMS/noarch/_    
 ### Need Help?
 You can post your queries to https://groups.google.com/forum/#!forum/rubix-users

--- a/README.md
+++ b/README.md
@@ -99,6 +99,10 @@ Note that you will need thrift-0.9.3 installed
 #### Generate RPM
     mvn clean package -Prpm,default
     
+    ## rpm and rpmbuild is required
+    ## To install rpm on Mac OS X
+    brew install rpm
+    
 RPM is created in _rubix-rpm/target/rpm/qubole-rubix/RPMS/noarch/_    
 ### Need Help?
 You can post your queries to https://groups.google.com/forum/#!forum/rubix-users

--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -47,9 +47,6 @@
             <groupId>com.qubole.rubix</groupId>
             <artifactId>rubix-tests</artifactId>
         </dependency>
-
-
-
     </dependencies>
 
     <profiles>
@@ -115,7 +112,6 @@
                                     </descriptors>
                                 </configuration>
                             </execution>
-
                         </executions>
                     </plugin>
                 </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,7 @@
         <module>rubix-hadoop1</module>
         <module>rubix-tests</module>
         <module>assembly</module>
+        <module>rubix-rpm</module>
     </modules>
 
     <dependencyManagement>

--- a/rubix-rpm/pom.xml
+++ b/rubix-rpm/pom.xml
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>rubix-root</artifactId>
+        <groupId>com.qubole.rubix</groupId>
+        <version>0.2.12-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>rubix-rpm</artifactId>
+    <properties>
+        <app.home>/usr/lib/rubix</app.home>
+        <project.build.sourceEncoding>utf-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.qubole.rubix</groupId>
+            <artifactId>rubix-bookkeeper</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.qubole.rubix</groupId>
+            <artifactId>rubix-hadoop1</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.qubole.rubix</groupId>
+            <artifactId>rubix-presto</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.qubole.rubix</groupId>
+            <artifactId>rubix-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.qubole.rubix</groupId>
+            <artifactId>rubix-spi</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.qubole.rubix</groupId>
+            <artifactId>rubix-hadoop2</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.qubole.rubix</groupId>
+            <artifactId>rubix-tests</artifactId>
+        </dependency>
+    </dependencies>
+
+    <profiles>
+        <profile>
+            <id>rpm</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>rpm-maven-plugin</artifactId>
+                        <version>2.1.5</version>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>rpm</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <name>qubole-rubix</name>
+                            <copyright>2015, Qubole</copyright>
+                            <group>Applications/Databases</group>
+                            <description>RPM Package for Rubix (https://github.com/qubole/rubix</description>
+                            <mappings>
+                                <mapping>
+                                    <directory>${app.home}/lib/</directory>
+                                    <dependency>
+                                        <includes>
+                                            <include>com.qubole.rubix:rubix-bookkeeper</include>
+                                            <include>com.qubole.rubix:rubix-hadoop1</include>
+                                            <include>com.qubole.rubix:rubix-hadoop2</include>
+                                            <include>com.qubole.rubix:rubix-spi</include>
+                                            <include>com.qubole.rubix:rubix-presto</include>
+                                            <include>com.qubole.rubix:rubix-core</include>
+                                        </includes>
+                                    </dependency>
+                                    <artifact/>
+                                </mapping>
+                                <mapping>
+                                    <directory>${app.home}/conf</directory>
+                                    <!-- <configuration>true</configuration>
+                                    <sources>
+                                        <source>
+                                            <location>${project.build.outputDirectory}/app.properties</location>
+                                            <destination>app.sample.properties</destination>
+                                        </source>
+                                    </sources>-->
+                                </mapping>
+                                <mapping>
+                                    <directory>${app.home}/logs</directory>
+                                </mapping>
+                            </mappings>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+</project>


### PR DESCRIPTION
Generate RPM with instructions in README. RPM is not generated
in _default_ or _release_ profile. 

The RPM contents are:
```
/usr/lib/rubix/conf
/usr/lib/rubix/lib
/usr/lib/rubix/lib/rubix-bookkeeper-0.2.12-SNAPSHOT.jar
/usr/lib/rubix/lib/rubix-core-0.2.12-SNAPSHOT.jar
/usr/lib/rubix/lib/rubix-hadoop1-0.2.12-SNAPSHOT.jar
/usr/lib/rubix/lib/rubix-hadoop2-0.2.12-SNAPSHOT.jar
/usr/lib/rubix/lib/rubix-presto-0.2.12-SNAPSHOT.jar
/usr/lib/rubix/lib/rubix-rpm-0.2.12-SNAPSHOT.jar
/usr/lib/rubix/lib/rubix-spi-0.2.12-SNAPSHOT.jar
/usr/lib/rubix/logs 
```

The content will evolve with installation code.
