### PR TITLE
fix: dev: Assigning a non-zero weight for each of the files in the cache to start eviction

### DIFF
--- a/rubix-bookkeeper/src/main/java/com/qubole/rubix/bookkeeper/FileMetadata.java
+++ b/rubix-bookkeeper/src/main/java/com/qubole/rubix/bookkeeper/FileMetadata.java
@@ -219,6 +219,6 @@ public class FileMetadata
     public int getWeight(Configuration conf)
     {
         // normal entries have no weight
-        return 0;
+        return 1;
     }
 }


### PR DESCRIPTION
as per guava source code
https://github.com/google/guava/blob/master/guava/src/com/google/common/cache/LocalCache.java#L2623

the weight of individual items needs to be a positive integer to have that item eligible for eviction.