### PR TITLE
fix: dev: #107: Fix creation of unnecessary zero bytes file in the cache

### DIFF
--- a/rubix-bookkeeper/src/main/java/com/qubole/rubix/bookkeeper/BookKeeper.java
+++ b/rubix-bookkeeper/src/main/java/com/qubole/rubix/bookkeeper/BookKeeper.java
@@ -137,17 +137,17 @@ public class BookKeeper
             for (long blockNum = startBlock; blockNum < endBlock; blockNum++) {
                 totalRequests++;
                 long split = (blockNum * blockSize) / splitSize;
-                if (md.isBlockCached(blockNum)) {
-                    blockLocations.add(new BlockLocation(Location.CACHED, blockSplits.get(split)));
-                    cachedRequests++;
+                if (!blockSplits.get(split).equalsIgnoreCase(nodeName)) {
+                    blockLocations.add(new BlockLocation(Location.NON_LOCAL, blockSplits.get(split)));
                 }
                 else {
-                    if (blockSplits.get(split).equalsIgnoreCase(nodeName)) {
-                        blockLocations.add(new BlockLocation(Location.LOCAL, blockSplits.get(split)));
-                        remoteRequests++;
+                    if (md.isBlockCached(blockNum)) {
+                        blockLocations.add(new BlockLocation(Location.CACHED, blockSplits.get(split)));
+                        cachedRequests++;
                     }
                     else {
-                        blockLocations.add(new BlockLocation(Location.NON_LOCAL, blockSplits.get(split)));
+                        blockLocations.add(new BlockLocation(Location.LOCAL, blockSplits.get(split)));
+                        remoteRequests++;
                     }
                 }
             }

--- a/rubix-core/src/main/java/com/qubole/rubix/core/CachingInputStream.java
+++ b/rubix-core/src/main/java/com/qubole/rubix/core/CachingInputStream.java
@@ -34,7 +34,6 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.util.DirectBufferPool;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.HashMap;
@@ -134,19 +133,6 @@ public class CachingInputStream
         this.blockSize = CacheConfig.getBlockSize(conf);
         this.localPath = CacheConfig.getLocalPath(remotePath, conf);
         this.diskReadBufferSize = CacheConfig.getDiskReadBufferSizeDefault(conf);
-        File file = new File(localPath);
-        if (!file.exists()) {
-            try {
-                file.createNewFile();
-            }
-            catch (IOException e) {
-                log.error("Error in creating local file " + localPath, e);
-                // reset bookkeeper client so that we take direct route
-                this.bookKeeperClient = null;
-            }
-            file.setReadable(true, false);
-            file.setWritable(true, false);
-        }
     }
 
     private FSDataInputStream getParentDataInputStream() throws IOException


### PR DESCRIPTION
After the fix:

```
[ec2-user@ip-10-0-0-251 ~]$ find /media/ephemeral0/fcache/bigdata-sets/perf/data/tpcds/parquet/scale_1000/store_sales/ -type f -size 0b -print
[ec2-user@ip-10-0-0-251 ~]$   

```

```
[ec2-user@ip-10-0-0-251 ~]$ ls -lrt /media/ephemeral0/fcache/bigdata-sets/perf/data/tpcds/parquet/scale_1000/store_sales/00000*
-rw-r--r-- 1 yarn yarn        7 Mar 22 23:56 /media/ephemeral0/fcache/bigdata-sets/perf/data/tpcds/parquet/scale_1000/store_sales/000003_mdfile
-rw-rw-rw- 1 yarn yarn 57186437 Mar 22 23:56 /media/ephemeral0/fcache/bigdata-sets/perf/data/tpcds/parquet/scale_1000/store_sales/000003
```