### PR TITLE
Send registered metrics to StatsD via StatsDReporter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,13 @@
       <tag>HEAD</tag>
   </scm>
 
+    <repositories>
+        <repository>
+            <id>spring-plugins</id>
+            <url>http://repo.spring.io/libs-release/</url>
+        </repository>
+    </repositories>
+
     <inceptionYear>2016</inceptionYear>
     <organization>
         <name>Qubole</name>
@@ -52,6 +59,7 @@
         <dep.hadoop2.version>2.6.0</dep.hadoop2.version>
         <dep.metrics.version>3.1.0</dep.metrics.version>
         <dep.testng.version>6.9.8</dep.testng.version>
+        <dep.metrics-statsd.version>4.2.0</dep.metrics-statsd.version>
     </properties>
 
     <modules>
@@ -144,6 +152,18 @@
                 <artifactId>metrics-core</artifactId>
                 <version>${dep.metrics.version}</version>
                 <scope>provided</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>com.readytalk</groupId>
+                <artifactId>metrics3-statsd</artifactId>
+                <version>${dep.metrics-statsd.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.readytalk</groupId>
+                <artifactId>metrics-statsd-common</artifactId>
+                <version>${dep.metrics-statsd.version}</version>
             </dependency>
 
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,13 @@
         <module>rubix-rpm</module>
     </modules>
 
+    <repositories>
+        <repository>
+            <id>spring-plugins</id>
+            <url>http://repo.spring.io/libs-release/</url>
+        </repository>
+    </repositories>
+
     <dependencyManagement>
         <dependencies>
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -36,13 +36,6 @@
       <tag>HEAD</tag>
   </scm>
 
-    <repositories>
-        <repository>
-            <id>spring-plugins</id>
-            <url>http://repo.spring.io/libs-release/</url>
-        </repository>
-    </repositories>
-
     <inceptionYear>2016</inceptionYear>
     <organization>
         <name>Qubole</name>

--- a/rubix-bookkeeper/pom.xml
+++ b/rubix-bookkeeper/pom.xml
@@ -112,12 +112,18 @@
                             <artifactSet>
                                 <includes>
                                     <include>com.google.guava:guava</include>
+                                    <include>com.readytalk:metrics-statsd-common</include>
+                                    <include>com.readytalk:metrics3-statsd</include>
                                 </includes>
                             </artifactSet>
                             <relocations>
                                 <relocation>
                                     <pattern>com.google</pattern>
                                     <shadedPattern>com.google.shaded</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>com.readytalk</pattern>
+                                    <shadedPattern>com.readytalk.shaded</shadedPattern>
                                 </relocation>
                             </relocations>
 

--- a/rubix-bookkeeper/pom.xml
+++ b/rubix-bookkeeper/pom.xml
@@ -69,7 +69,6 @@
             <groupId>com.readytalk</groupId>
             <artifactId>metrics3-statsd</artifactId>
             <version>${dep.metrics-statsd.version}</version>
-            <!--<scope>compile</scope>-->
         </dependency>
 
         <dependency>

--- a/rubix-bookkeeper/pom.xml
+++ b/rubix-bookkeeper/pom.xml
@@ -66,6 +66,19 @@
         </dependency>
 
         <dependency>
+            <groupId>com.readytalk</groupId>
+            <artifactId>metrics3-statsd</artifactId>
+            <version>${dep.metrics-statsd.version}</version>
+            <!--<scope>compile</scope>-->
+        </dependency>
+
+        <dependency>
+            <groupId>com.readytalk</groupId>
+            <artifactId>metrics-statsd-common</artifactId>
+            <version>${dep.metrics-statsd.version}</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <version>${dep.testng.version}</version>

--- a/rubix-bookkeeper/src/main/java/com/qubole/rubix/bookkeeper/BookKeeperServer.java
+++ b/rubix-bookkeeper/src/main/java/com/qubole/rubix/bookkeeper/BookKeeperServer.java
@@ -118,10 +118,11 @@ public class BookKeeperServer extends Configured implements Tool
    */
   private static void registerMetrics(Configuration conf)
   {
-    log.info("Setting up StatsDReporter");
-    StatsDReporter.forRegistry(metrics)
-        .build(CacheConfig.getStatsDMetricsHost(conf), CacheConfig.getStatsDMetricsPort(conf))
-        .start(CacheConfig.getStatsDMetricsInterval(conf), TimeUnit.MILLISECONDS);
+    if (CacheConfig.isOnMaster(conf)) {
+      StatsDReporter.forRegistry(metrics)
+          .build(CacheConfig.getStatsDMetricsHost(conf), CacheConfig.getStatsDMetricsPort(conf))
+          .start(CacheConfig.getStatsDMetricsInterval(conf), TimeUnit.MILLISECONDS);
+    }
 
     metrics.register(METRIC_BOOKKEEPER_LIVENESS_CHECK, new Gauge<Integer>()
     {

--- a/rubix-bookkeeper/src/main/java/com/qubole/rubix/bookkeeper/BookKeeperServer.java
+++ b/rubix-bookkeeper/src/main/java/com/qubole/rubix/bookkeeper/BookKeeperServer.java
@@ -118,7 +118,9 @@ public class BookKeeperServer extends Configured implements Tool
    */
   private static void registerMetrics(Configuration conf)
   {
-    if (CacheConfig.isOnMaster(conf)) {
+    if ((CacheConfig.isOnMaster(conf) && CacheConfig.isReportStatsdMetricsOnMaster(conf))
+        || (!CacheConfig.isOnMaster(conf) && CacheConfig.isReportStatsdMetricsOnWorker(conf))) {
+      log.info("Reporting metrics to StatsD");
       StatsDReporter.forRegistry(metrics)
           .build(CacheConfig.getStatsDMetricsHost(conf), CacheConfig.getStatsDMetricsPort(conf))
           .start(CacheConfig.getStatsDMetricsInterval(conf), TimeUnit.MILLISECONDS);

--- a/rubix-bookkeeper/src/main/java/com/qubole/rubix/bookkeeper/BookKeeperServer.java
+++ b/rubix-bookkeeper/src/main/java/com/qubole/rubix/bookkeeper/BookKeeperServer.java
@@ -17,6 +17,8 @@ import com.codahale.metrics.MetricRegistry;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Throwables;
 import com.qubole.rubix.spi.BookKeeperService;
+import com.qubole.rubix.spi.CacheConfig;
+import com.readytalk.metrics.StatsDReporter;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.conf.Configuration;
@@ -30,6 +32,7 @@ import org.apache.thrift.shaded.transport.TServerTransport;
 import org.apache.thrift.shaded.transport.TTransportException;
 
 import java.io.FileNotFoundException;
+import java.util.concurrent.TimeUnit;
 
 import static com.qubole.rubix.spi.CacheConfig.getServerMaxThreads;
 import static com.qubole.rubix.spi.CacheConfig.getServerPort;
@@ -89,7 +92,7 @@ public class BookKeeperServer extends Configured implements Tool
       return;
     }
 
-    registerMetrics();
+    registerMetrics(conf);
 
     DiskMonitorService diskMonitorService = new DiskMonitorService(conf, bookKeeper);
     diskMonitorService.startAsync();
@@ -113,8 +116,13 @@ public class BookKeeperServer extends Configured implements Tool
   /**
    * Register desired metrics.
    */
-  private static void registerMetrics()
+  private static void registerMetrics(Configuration conf)
   {
+    log.info("Setting up StatsDReporter");
+    StatsDReporter.forRegistry(metrics)
+        .build(CacheConfig.getStatsDMetricsHost(conf), CacheConfig.getStatsDMetricsPort(conf))
+        .start(CacheConfig.getStatsDMetricsInterval(conf), TimeUnit.MILLISECONDS);
+
     metrics.register(METRIC_BOOKKEEPER_LIVENESS_CHECK, new Gauge<Integer>()
     {
       @Override

--- a/rubix-bookkeeper/src/test/java/com/qubole/rubix/bookkeeper/TestBookKeeperServer.java
+++ b/rubix-bookkeeper/src/test/java/com/qubole/rubix/bookkeeper/TestBookKeeperServer.java
@@ -21,15 +21,23 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
+import java.net.DatagramPacket;
+import java.net.DatagramSocket;
+import java.net.SocketException;
+import java.net.SocketTimeoutException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
 
 public class TestBookKeeperServer
 {
   private static final Log log = LogFactory.getLog(TestBookKeeperServer.class.getName());
+  private static final int PACKET_SIZE = 32;
+  private static final int SOCKET_TIMEOUT = 5000;
 
   private MetricRegistry metrics;
   private Configuration conf;
@@ -103,6 +111,190 @@ public class TestBookKeeperServer
     while (BookKeeperServer.isServerUp()) {
       Thread.sleep(200);
       log.info("Waiting for BookKeeper Server to shut down");
+    }
+  }
+
+  /**
+   * Verify that StatsDReporter reports metrics to StatsD on a master node when configured to.
+   *
+   * @throws InterruptedException if the current thread is interrupted while sleeping.
+   * @throws IOException if an I/O error occurs while waiting for a response.
+   */
+  @Test
+  public void verifyStatsDReporterIsReporting_onMaster_reportOnMaster() throws InterruptedException, IOException
+  {
+    final int statsDPort = 6789;
+    final int testCasePort = 5678;
+    final boolean shouldReport = true;
+
+    startServersForTestingStatsDReporterOnMaster(statsDPort, testCasePort, shouldReport);
+
+    assertTrue(isStatsDReporterFiring(testCasePort), "BookKeeperServer is not reporting to StatsD");
+  }
+
+  /**
+   * Verify that StatsDReporter does not report metrics to StatsD on a master node when configured not to.
+   *
+   * @throws InterruptedException if the current thread is interrupted while sleeping.
+   * @throws IOException if an I/O error occurs while waiting for a response.
+   */
+  @Test
+  public void verifyStatsDReporterIsReporting_onMaster_doNotReportOnMaster() throws InterruptedException, IOException
+  {
+    final int statsDPort = 6790;
+    final int testCasePort = 5679;
+    final boolean shouldReport = false;
+
+    startServersForTestingStatsDReporterOnMaster(statsDPort, testCasePort, shouldReport);
+
+    assertFalse(isStatsDReporterFiring(testCasePort), "BookKeeperServer should not report to StatsD");
+  }
+
+  /**
+   * Verify that StatsDReporter reports metrics to StatsD on a worker node when configured to.
+   *
+   * @throws InterruptedException if the current thread is interrupted while sleeping.
+   * @throws IOException if an I/O error occurs while waiting for a response.
+   */
+  @Test
+  public void verifyStatsDReporterIsReporting_onWorker_reportOnWorker() throws InterruptedException, IOException
+  {
+    final int statsDPort = 6791;
+    final int testCasePort = 5680;
+    final boolean shouldReport = true;
+
+    startServersForTestingStatsDReporterForWorker(statsDPort, testCasePort, shouldReport);
+
+    assertTrue(isStatsDReporterFiring(testCasePort), "BookKeeperServer is not reporting to StatsD");
+  }
+
+  /**
+   * Verify that StatsDReporter does not report metrics to StatsD on a master node when configured not to.
+   *
+   * @throws InterruptedException if the current thread is interrupted while sleeping.
+   * @throws IOException if an I/O error occurs while waiting for a response.
+   */
+  @Test
+  public void verifyStatsDReporterIsReporting_onWorker_doNotReportOnWorker() throws InterruptedException, IOException
+  {
+    final int statsDPort = 6792;
+    final int testCasePort = 5681;
+    final boolean shouldReport = false;
+
+    startServersForTestingStatsDReporterForWorker(statsDPort, testCasePort, shouldReport);
+
+    assertFalse(isStatsDReporterFiring(testCasePort), "BookKeeperServer should not report to StatsD");
+  }
+
+  /**
+   * Start & configure the servers necessary for running & testing StatsDReporter on a master node.
+   *
+   * @param statsDPort The port to send StatsD metrics to.
+   * @param testCasePort The port from which to receive responses from the mock StatsD server.
+   * @param shouldReportMetrics Whether metrics should be reported.
+   * @throws SocketException if the socket for the mock StatsD server could not be created or bound.
+   * @throws InterruptedException if the current thread is interrupted while sleeping.
+   */
+  private void startServersForTestingStatsDReporterOnMaster(int statsDPort, int testCasePort, boolean shouldReportMetrics) throws SocketException, InterruptedException
+  {
+    CacheConfig.setOnMaster(conf, true);
+    CacheConfig.setReportStatsdMetricsOnMaster(conf, shouldReportMetrics);
+
+    startServersForTestingStatsDReporter(statsDPort, testCasePort);
+  }
+
+  /**
+   * Start & configure the servers necessary for running & testing StatsDReporter on a worker node.
+   *
+   * @param statsDPort The port to send StatsD metrics to.
+   * @param testCasePort The port from which to receive responses from the mock StatsD server.
+   * @param shouldReportMetrics Whether metrics should be reported.
+   * @throws SocketException if the socket for the mock StatsD server could not be created or bound.
+   * @throws InterruptedException if the current thread is interrupted while sleeping.
+   */
+  private void startServersForTestingStatsDReporterForWorker(int statsDPort, int testCasePort, boolean shouldReportMetrics) throws SocketException, InterruptedException
+  {
+    CacheConfig.setOnMaster(conf, false);
+    CacheConfig.setReportStatsdMetricsOnWorker(conf, shouldReportMetrics);
+
+    startServersForTestingStatsDReporter(statsDPort, testCasePort);
+  }
+
+  /**
+   * Start & configure the servers necessary for running & testing StatsDReporter.
+   *
+   * @param statsDPort The port to send StatsD metrics to.
+   * @param testCasePort The port from which to receive responses from the StatsD
+   * @throws SocketException if the socket for the mock StatsD server could not be created or bound.
+   * @throws InterruptedException if the current thread is interrupted while sleeping.
+   */
+  private void startServersForTestingStatsDReporter(int statsDPort, int testCasePort) throws SocketException, InterruptedException
+  {
+    CacheConfig.setStatsDMetricsPort(conf, statsDPort);
+    CacheConfig.setStatsDMetricsInterval(conf, 1000);
+
+    new MockStatsDThread(statsDPort, testCasePort).start();
+    startBookKeeperServer();
+  }
+
+  /**
+   * Check if StatsDReporter is correctly firing metrics.
+   *
+   * @param receivePort The port on which to receive responses from the mock StatsD server.
+   * @return True if the mock StatsDReporter has received a response
+   * @throws IOException if an I/O error occurs while waiting for a response.
+   */
+  private boolean isStatsDReporterFiring(int receivePort) throws IOException
+  {
+    byte[] data = new byte[PACKET_SIZE];
+    DatagramSocket socket = new DatagramSocket(receivePort);
+    DatagramPacket packet = new DatagramPacket(data, data.length);
+
+    socket.setSoTimeout(SOCKET_TIMEOUT);
+    try {
+      socket.receive(packet);
+    }
+    catch (SocketTimeoutException e) {
+      return false;
+    }
+
+    return true;
+  }
+
+  /**
+   * Thread to capture UDP requests from StatsDReporter intended for StatsD.
+   */
+  private static class MockStatsDThread extends Thread
+  {
+    // The socket to send/receive StatsD metrics from.
+    private final DatagramSocket socket;
+
+    // The port the current test case is expecting to receive acknowledgement from.
+    private final int testCasePort;
+
+    private MockStatsDThread(int statsDPort, int testCasePort) throws SocketException
+    {
+      this.socket = new DatagramSocket(statsDPort);
+      this.testCasePort = testCasePort;
+    }
+
+    @Override
+    public void run()
+    {
+      while (true) {
+        try {
+          byte[] response = new byte[PACKET_SIZE];
+          final DatagramPacket receivedPacket = new DatagramPacket(response, response.length);
+          socket.receive(receivedPacket);
+
+          String responseMessage = "Received from MockStatsD";
+          response = responseMessage.getBytes();
+          socket.send(new DatagramPacket(response, response.length, receivedPacket.getAddress(), testCasePort));
+        }
+        catch (IOException e) {
+          log.error("Error sending/receiving UDP packets", e);
+        }
+      }
     }
   }
 }

--- a/rubix-spi/src/main/java/com/qubole/rubix/spi/CacheConfig.java
+++ b/rubix-spi/src/main/java/com/qubole/rubix/spi/CacheConfig.java
@@ -60,6 +60,9 @@ public class CacheConfig
   private static final String KEY_SERVER_PORT = "hadoop.cache.data.bookkeeper.port";
   private static final String KEY_SERVER_MAX_THREADS = "hadoop.cache.data.bookkeeper.max-threads";
   private static final String KEY_SOCKET_READ_TIMEOUT = "hadoop.cache.network.socket.read.timeout";
+  private static final String KEY_STATSD_METRICS_HOST = "rubix.statsd.metrics.host";
+  private static final String KEY_STATSD_METRICS_INTERVAL = "rubix.statsd.metrics.interval";
+  private static final String KEY_STATSD_METRICS_PORT = "rubix.statsd.metrics.port";
 
   // default values
   private static final int DEFAULT_BLOCK_SIZE = 1 * 1024 * 1024; // 1MB
@@ -93,6 +96,9 @@ public class CacheConfig
   private static final int DEFAULT_SERVER_MAX_THREADS = Integer.MAX_VALUE;
   private static final int DEFAULT_SERVER_PORT = 8899;
   private static final int DEFAULT_SOCKET_READ_TIMEOUT = 30000; // ms
+  private static final String DEFAULT_STATSD_METRICS_HOST = "127.0.0.1"; // localhost
+  private static final int DEFAULT_STATSD_METRICS_INTERVAL = 10000; // ms
+  private static final int DEFAULT_STATSD_METRICS_PORT = 8125; // default StatsD port
 
   private CacheConfig()
   {
@@ -231,6 +237,21 @@ public class CacheConfig
   public static int getSocketReadTimeOut(Configuration conf)
   {
     return conf.getInt(KEY_SOCKET_READ_TIMEOUT, DEFAULT_SOCKET_READ_TIMEOUT);
+  }
+
+  public static String getStatsDMetricsHost(Configuration conf)
+  {
+    return conf.get(KEY_STATSD_METRICS_HOST, DEFAULT_STATSD_METRICS_HOST);
+  }
+
+  public static int getStatsDMetricsInterval(Configuration conf)
+  {
+    return conf.getInt(KEY_STATSD_METRICS_INTERVAL, DEFAULT_STATSD_METRICS_INTERVAL);
+  }
+
+  public static int getStatsDMetricsPort(Configuration conf)
+  {
+    return conf.getInt(KEY_STATSD_METRICS_PORT, DEFAULT_STATSD_METRICS_PORT);
   }
 
   public static boolean isCacheDataEnabled(Configuration conf)

--- a/rubix-spi/src/main/java/com/qubole/rubix/spi/CacheConfig.java
+++ b/rubix-spi/src/main/java/com/qubole/rubix/spi/CacheConfig.java
@@ -52,6 +52,11 @@ public class CacheConfig
   private static final String KEY_LOCAL_TRANSFER_BUFFER_SIZE = "hadoop.cache.data.buffer.size";
   private static final String KEY_LOCAL_SERVER_PORT = "hadoop.cache.data.local.server.port";
   private static final String KEY_MAX_RETRIES = "hadoop.cache.data.client.num-retries";
+  private static final String KEY_METRICS_STATSD_HOST = "rubix.metrics.statsd.host";
+  private static final String KEY_METRICS_STATSD_INTERVAL = "rubix.metrics.statsd.interval";
+  private static final String KEY_METRICS_STATSD_PORT = "rubix.metrics.statsd.port";
+  private static final String KEY_METRICS_STATSD_REPORT_ON_MASTER = "rubix.metrics.statsd.report-master";
+  private static final String KEY_METRICS_STATSD_REPORT_ON_WORKER = "rubix.metrics.statsd.report-worker";
   private static final String KEY_PARALLEL_WARMUP = "rubix.parallel.warmup";
   private static final String KEY_PROCESS_THREAD_INITIAL_DELAY = "rubix.request.process.initial.delay";
   private static final String KEY_PROCESS_THREAD_INTERVAL = "rubix.request.process.interval";
@@ -61,9 +66,6 @@ public class CacheConfig
   private static final String KEY_SERVER_PORT = "hadoop.cache.data.bookkeeper.port";
   private static final String KEY_SERVER_MAX_THREADS = "hadoop.cache.data.bookkeeper.max-threads";
   private static final String KEY_SOCKET_READ_TIMEOUT = "hadoop.cache.network.socket.read.timeout";
-  private static final String KEY_STATSD_METRICS_HOST = "rubix.statsd.metrics.host";
-  private static final String KEY_STATSD_METRICS_INTERVAL = "rubix.statsd.metrics.interval";
-  private static final String KEY_STATSD_METRICS_PORT = "rubix.statsd.metrics.port";
 
   // default values
   private static final int DEFAULT_BLOCK_SIZE = 1 * 1024 * 1024; // 1MB
@@ -89,6 +91,11 @@ public class CacheConfig
   private static final int DEFAULT_LOCAL_SERVER_PORT = 8898;
   private static final int DEFAULT_MAX_BUFFER_SIZE = 1024;
   private static final int DEFAULT_MAX_RETRIES = 3;
+  private static final String DEFAULT_METRICS_STATSD_HOST = "127.0.0.1"; // localhost
+  private static final int DEFAULT_METRICS_STATSD_INTERVAL = 10000; // ms
+  private static final int DEFAULT_METRICS_STATSD_PORT = 8125; // default StatsD port
+  private static final boolean DEFAULT_METRICS_STATSD_REPORT_ON_MASTER = false;
+  private static final boolean DEFAULT_METRICS_STATSD_REPORT_ON_WORKER = false;
   private static final boolean DEFAULT_PARALLEL_WARMUP = false;
   private static final int DEFAULT_PROCESS_THREAD_INITIAL_DELAY = 1000; // ms
   private static final int DEFAULT_PROCESS_THREAD_INTERVAL = 1000; // ms
@@ -98,9 +105,6 @@ public class CacheConfig
   private static final int DEFAULT_SERVER_MAX_THREADS = Integer.MAX_VALUE;
   private static final int DEFAULT_SERVER_PORT = 8899;
   private static final int DEFAULT_SOCKET_READ_TIMEOUT = 30000; // ms
-  private static final String DEFAULT_STATSD_METRICS_HOST = "127.0.0.1"; // localhost
-  private static final int DEFAULT_STATSD_METRICS_INTERVAL = 10000; // ms
-  private static final int DEFAULT_STATSD_METRICS_PORT = 8125; // default StatsD port
 
   private CacheConfig()
   {
@@ -243,17 +247,17 @@ public class CacheConfig
 
   public static String getStatsDMetricsHost(Configuration conf)
   {
-    return conf.get(KEY_STATSD_METRICS_HOST, DEFAULT_STATSD_METRICS_HOST);
+    return conf.get(KEY_METRICS_STATSD_HOST, DEFAULT_METRICS_STATSD_HOST);
   }
 
   public static int getStatsDMetricsInterval(Configuration conf)
   {
-    return conf.getInt(KEY_STATSD_METRICS_INTERVAL, DEFAULT_STATSD_METRICS_INTERVAL);
+    return conf.getInt(KEY_METRICS_STATSD_INTERVAL, DEFAULT_METRICS_STATSD_INTERVAL);
   }
 
   public static int getStatsDMetricsPort(Configuration conf)
   {
-    return conf.getInt(KEY_STATSD_METRICS_PORT, DEFAULT_STATSD_METRICS_PORT);
+    return conf.getInt(KEY_METRICS_STATSD_PORT, DEFAULT_METRICS_STATSD_PORT);
   }
 
   public static boolean isCacheDataEnabled(Configuration conf)
@@ -264,6 +268,16 @@ public class CacheConfig
   public static boolean isOnMaster(Configuration conf)
   {
     return conf.getBoolean(KEY_RUBIX_ON_MASTER, DEFAULT_RUBIX_ON_MASTER);
+  }
+
+  public static boolean isReportStatsdMetricsOnMaster(Configuration conf)
+  {
+    return conf.getBoolean(KEY_METRICS_STATSD_REPORT_ON_MASTER, DEFAULT_METRICS_STATSD_REPORT_ON_MASTER);
+  }
+
+  public static boolean isReportStatsdMetricsOnWorker(Configuration conf)
+  {
+    return conf.getBoolean(KEY_METRICS_STATSD_REPORT_ON_WORKER, DEFAULT_METRICS_STATSD_REPORT_ON_WORKER);
   }
 
   public static boolean isStrictMode(Configuration conf)
@@ -346,6 +360,11 @@ public class CacheConfig
     conf.setInt(KEY_DATA_CACHE_MAX_DISKS, maxDisks);
   }
 
+  public static void setOnMaster(Configuration conf, boolean onMaster)
+  {
+    conf.setBoolean(KEY_RUBIX_ON_MASTER, onMaster);
+  }
+
   public static void setRemoteFetchProcessInterval(Configuration conf, int interval)
   {
     conf.setInt(KEY_REMOTE_FETCH_PROCESS_INTERVAL, interval);
@@ -354,5 +373,25 @@ public class CacheConfig
   public static void setServerPort(Configuration conf, int serverPort)
   {
     conf.setInt(KEY_SERVER_PORT, serverPort);
+  }
+
+  public static void setStatsDMetricsInterval(Configuration conf, int interval)
+  {
+    conf.setInt(KEY_METRICS_STATSD_INTERVAL, interval);
+  }
+
+  public static void setStatsDMetricsPort(Configuration conf, int port)
+  {
+    conf.setInt(KEY_METRICS_STATSD_PORT, port);
+  }
+
+  public static void setReportStatsdMetricsOnMaster(Configuration conf, boolean reportOnMaster)
+  {
+    conf.setBoolean(KEY_METRICS_STATSD_REPORT_ON_MASTER, reportOnMaster);
+  }
+
+  public static void setReportStatsdMetricsOnWorker(Configuration conf, boolean reportOnWorker)
+  {
+    conf.setBoolean(KEY_METRICS_STATSD_REPORT_ON_WORKER, reportOnWorker);
   }
 }

--- a/rubix-spi/src/main/java/com/qubole/rubix/spi/CacheConfig.java
+++ b/rubix-spi/src/main/java/com/qubole/rubix/spi/CacheConfig.java
@@ -57,6 +57,7 @@ public class CacheConfig
   private static final String KEY_PROCESS_THREAD_INTERVAL = "rubix.request.process.interval";
   private static final String KEY_REMOTE_FETCH_PROCESS_INTERVAL = "rubix.remotefetch.interval";
   private static final String KEY_REMOTE_FETCH_THREADS = "rubix.remotefetch.threads";
+  private static final String KEY_RUBIX_ON_MASTER = "rubix.cluster.on-master";
   private static final String KEY_SERVER_PORT = "hadoop.cache.data.bookkeeper.port";
   private static final String KEY_SERVER_MAX_THREADS = "hadoop.cache.data.bookkeeper.max-threads";
   private static final String KEY_SOCKET_READ_TIMEOUT = "hadoop.cache.network.socket.read.timeout";
@@ -93,6 +94,7 @@ public class CacheConfig
   private static final int DEFAULT_PROCESS_THREAD_INTERVAL = 1000; // ms
   private static final int DEFAULT_REMOTE_FETCH_PROCESS_INTERVAL = 10000; // ms
   private static final int DEFAULT_REMOTE_FETCH_THREADS = 10;
+  private static final boolean DEFAULT_RUBIX_ON_MASTER = false;
   private static final int DEFAULT_SERVER_MAX_THREADS = Integer.MAX_VALUE;
   private static final int DEFAULT_SERVER_PORT = 8899;
   private static final int DEFAULT_SOCKET_READ_TIMEOUT = 30000; // ms
@@ -257,6 +259,11 @@ public class CacheConfig
   public static boolean isCacheDataEnabled(Configuration conf)
   {
     return conf.getBoolean(KEY_CACHE_ENABLED, DEFAULT_DATA_CACHE_ENABLED);
+  }
+
+  public static boolean isOnMaster(Configuration conf)
+  {
+    return conf.getBoolean(KEY_RUBIX_ON_MASTER, DEFAULT_RUBIX_ON_MASTER);
   }
 
   public static boolean isStrictMode(Configuration conf)


### PR DESCRIPTION
- Passed smoke test on Qubole cluster
- Currently verifying that metrics are sent to DogStatsD on Qubole cluster using default config settings (localhost:8125)