### PR TITLE
new:usr:Add more details to Contribution Guide and a markdown file 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,9 +18,9 @@ Please read Contribution Guidelines in
 There are many other ways to contribute to RubiX besides code. We've outlined
 the most common ones below:
 
-* [Reporting Bugs]()
-* [Request Features]()
-* [Documentation]()
+* [Reporting Bugs](http://rubix.readthedocs.io/en/latest/contrib/issues.html)
+* Request Features (TBA)
+* [Documentation](http://rubix.readthedocs.io/en/latest/contrib/doc.html)
 
 For everything else, contact the maintainers on:
 * [User Group (Google)](https://groups.google.com/forum/#!forum/rubix-users)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ Thank you for taking the time to contribute to RubiX.
 For information on 
 
 * How to setup your development environment
-* Code conventions
+* Coding conventions
 * Step-by-Step for GitHub commits
 
 Please read Contribution Guidelines in 
@@ -15,13 +15,13 @@ Please read Contribution Guidelines in
 
 ## Everything Else
 
-There are many other ways to contribute to RubiX besides code. We've outlined
-the most common ones below:
+There are many other ways to contribute to RubiX besides directly writing code. 
+We've outlined the most common ones below:
 
 * [Reporting Bugs](http://rubix.readthedocs.io/en/latest/contrib/issues.html)
 * Request Features (TBA)
 * [Documentation](http://rubix.readthedocs.io/en/latest/contrib/doc.html)
 
-For everything else, contact the maintainers on:
+For everything else, contact the community on:
 * [User Group (Google)](https://groups.google.com/forum/#!forum/rubix-users)
 * [Slack Channel](https://join.slack.com/t/rubix-cache/signup?x=x-348094509318-348094608182)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,27 @@
+# Contributing to RubiX
+
+Thank you for taking the time to contribute to RubiX.
+
+## Development Guide
+
+For information on 
+
+* How to setup your development environment
+* Code conventions
+* Step-by-Step for GitHub commits
+
+Please read Contribution Guidelines in 
+[Rubix Documentation](http://rubix.readthedocs.io/en/latest/contrib/index.html)
+
+## Everything Else
+
+There are many other ways to contribute to RubiX besides code. We've outlined
+the most common ones below:
+
+* [Reporting Bugs]()
+* [Request Features]()
+* [Documentation]()
+
+For everything else, contact the maintainers on:
+* [User Group (Google)](https://groups.google.com/forum/#!forum/rubix-users)
+* [Slack Channel](https://join.slack.com/t/rubix-cache/signup?x=x-348094509318-348094608182)

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -3,7 +3,7 @@
 
 # You can set these variables from the command line.
 SPHINXOPTS    =
-SPHINXBUILD   = python3.6 -msphinx
+SPHINXBUILD   = python -msphinx
 SPHINXPROJ    = Rubix
 SOURCEDIR     = .
 BUILDDIR      = _build

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -3,7 +3,7 @@
 
 # You can set these variables from the command line.
 SPHINXOPTS    =
-SPHINXBUILD   = python -msphinx
+SPHINXBUILD   = python3.6 -msphinx
 SPHINXPROJ    = Rubix
 SOURCEDIR     = .
 BUILDDIR      = _build

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -47,7 +47,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'Rubix'
-copyright = u'2017, Qubole'
+copyright = u'2018, Qubole'
 author = u'Qubole'
 
 # The version info for the project you're documenting, acts as replacement for

--- a/docs/contrib/coding.md
+++ b/docs/contrib/coding.md
@@ -1,0 +1,3 @@
+# Code conventions
+
+Content to be added

--- a/docs/contrib/coding.md
+++ b/docs/contrib/coding.md
@@ -1,4 +1,4 @@
-# Code conventions
+# Coding conventions
 
 * two spaces, no tabs
 * no trailing whitespaces, blank lines should have no spaces

--- a/docs/contrib/coding.md
+++ b/docs/contrib/coding.md
@@ -1,3 +1,9 @@
 # Code conventions
 
-Content to be added
+* two spaces, no tabs
+* no trailing whitespaces, blank lines should have no spaces
+* Do not mix multiple fixes into a single commit. 
+* Add comments for your future selves and for your current/future peers
+* Do not make whitespace changes as part of your regular/feature commits. 
+* If you feel whitespace issues need to be fixed, please push a separate 
+  commit for the same. It will be approved quickly without any discussion.

--- a/docs/contrib/commit.md
+++ b/docs/contrib/commit.md
@@ -1,3 +1,63 @@
 # Commit Message
 
-Content to be added
+Commits are used as a source of truth for various reports. A couple of examples are:
+
+* Release Notes
+* Issues resolved for QA to plan the QA cycle.
+
+To be able to generate these reports, uniform commit messages are required. 
+All your commits should follow the following convention:
+
+For every commit please write a short (max 72 characters) summary in the first
+line followed with a blank line and then more detailed descriptions of the 
+change.
+
+Format of summary:
+
+    ACTION: AUDIENCE: COMMIT_MSG
+
+Description:
+
+    ACTION is one of 'chg', 'fix', 'new'
+    Is WHAT the change is about.
+    'chg' is for refactor, small improvement, cosmetic changes...
+    'fix' is for bug fixes
+    'new' is for new features, big improvement
+
+    AUDIENCE is one of 'dev', 'usr', 'pkg', 'test', 'doc'
+    Is WHO is concerned by the change.
+    'dev' is for developers (API changes, refactors...)
+    'usr' is for final users
+
+You will use your environment’s default editor (EDITOR=vi|emacs) to compose the
+commit message. Do NOT use the command line git commit -m “my mesg” as this 
+only allows you to write a single line that most of the times turns out to be 
+useless to others reading or reviewing your commit.
+
+## Example
+
+    new: dev: #124: report liveness metric for BookKeeper daemon (#139)
+
+    Add a liveness gauge that the daemon is up & alive. Right now, this 
+    is a simple check that a thread (reporter to be added in a subsequent 
+    commit) is alive. In the future, this simple framework will be used 
+    to add more comprehensive health checks. Ref: #140
+    
+The above example shows the commit summary is:
+
+* a single line composed of four columns
+* column 1 tells us the nature of the change or ACTION:  new
+* a short one-line summary of WHAT the commit is doing
+
+The description or the body of the commit message delves into more detail 
+that is intended to serve as a history for developers on the team on how the
+code is evolving. There are more immediate uses of this description however. 
+When you raise pull requests to make your contributions into the project, your 
+commit descriptions serve as explanations of WHY you fixed an issue. HOW you 
+fixed an issue is explained by code already. This is also the place where the 
+peer-reviewers will begin understanding your code. An unclear commit message is 
+the source of a lot of back and forth resulting in frustration between 
+reviewers and committers.
+ 
+Reference: <http://chris.beams.io/posts/git-commit/>
+

--- a/docs/contrib/commit.md
+++ b/docs/contrib/commit.md
@@ -1,0 +1,3 @@
+# Commit Message
+
+Content to be added

--- a/docs/contrib/develop.md
+++ b/docs/contrib/develop.md
@@ -1,4 +1,4 @@
-# Guideline for Contributors
+# How to contribute code on Github
 
 1. Fork your own copy of rubix into your github account by clicking on the "Fork" button
 2. Navigate to your account and clone that copy to your development box

--- a/docs/contrib/develop.md
+++ b/docs/contrib/develop.md
@@ -1,11 +1,57 @@
 # How to contribute code on Github
 
-1. Fork your own copy of rubix into your github account by clicking on the "Fork" button
-2. Navigate to your account and clone that copy to your development box
-git clone https://github.com/<username>/rubix
-3. Create a branch and start working on your change.
-4. Once you have done all the changes make a local commit and push to your repository. Make sure you run all the unit tests: `mvn clean install`
-This will run all the unit test.
-5. Create a Pull Request(PR)
-6. Contributors from rubix will review and approve or request changes.You may discuss these changes with the reviewer and  make changes in your private branch. Repeat the process between 4-6 until this is accepted by the reviewer.
-7. Once all the changes are approved, one contributor will push the change to the upstream code.
+### 1. Create a branch and start working on your change.
+  
+
+    cd rubix
+    git checkout -b new_rubix_branch
+     
+### 2. Code
+   
+* Adhere to code standards.
+* Include tests and ensure they pass.
+
+### 3. Commit
+
+For every commit please write a short (max 72 characters) summary in the first
+line followed with a blank line and then more detailed descriptions of the 
+change.
+
+_Don't forget a prefix!_
+
+More details in [Commit Guidelines](https://rubix.readthedocs.io/en/latest/contrib/commit.html)
+
+### 4. Update your branch
+  
+  
+    git fetch upstream
+    git rebase upstream/master
+  
+### 5. Push to remote
+
+
+    git push -u origin new_rubix_branch
+   
+### 6. Issue a [Pull Request](https://help.github.com/articles/proposing-changes-to-a-project-with-pull-requests/)
+
+* Navigate to the Rubix repository you just pushed to (e.g. <https://github.com/your-user-name/rubix>)
+* Click _Pull Request_.
+* Write your branch name in the branch field (this is filled with _master_ by default)
+* Click _Update Commit Range_.
+* Ensure the changesets you introduced are included in the _Commits_ tab.
+* Ensure that the _Files Changed_ incorporate all of your changes.
+* Fill in some details about your potential patch including a meaningful title. 
+* Click _Send pull request_.
+
+### 7. Respond to feedback
+
+The RubiX team may recommend adjustments to your code. Part of interacting with
+a healthy open-source community requires you to be open to learning new 
+techniques and strategies; _don’t get discouraged!_ Remember: if the RubiX 
+team suggest changes to your code, they care enough about your work that they 
+want to include it, and hope that you can assist by implementing those 
+revisions on your own.
+
+### 8. Postscript
+
+Once all the changes are approved, one contributor will push the change to the upstream code.

--- a/docs/contrib/doc.md
+++ b/docs/contrib/doc.md
@@ -1,0 +1,9 @@
+# Documentation Style Guide
+
+* Documentation uses [Sphinx](http://www.sphinx-doc.org/en/master/) documentation generator.  
+* Documentation is hosted on [ReadTheDocs](http://rubix.readthedocs.io/en/latest/)  
+* File issues if you notice bugs in documentation or to request more information.
+Label issues with `doc` 
+* Contributions to documentation is accepted as a Pull Request. 
+* Choose Markdown if you will add new pages
+* Choose Rich Structured Text (rst) for indexes or if the documentation needs tables. 

--- a/docs/contrib/env.md
+++ b/docs/contrib/env.md
@@ -1,0 +1,3 @@
+# Developer Environment
+
+Content to be added.

--- a/docs/contrib/env.md
+++ b/docs/contrib/env.md
@@ -1,3 +1,24 @@
 # Developer Environment
 
-Content to be added.
+Rubix is a Maven project and uses Java 8. It uses JUnit as the testing framework.
+Ensure that you have a development environment that support the above 
+configuration.
+
+* Fork your own copy of RubiX into your github account by clicking on the "Fork" button
+* Navigate to your account and clone that copy to your development box
+
+    
+    git clone https://github.com/\<username\>/rubix
+
+
+* Run tests in the RubiX root directory.
+ 
+
+    mvn test
+   
+
+* Add Qubole RubiX as upstream
+
+
+    git remote add upstream https://github.com/qubole/rubix.git
+    git fetch upstream

--- a/docs/contrib/index.rst
+++ b/docs/contrib/index.rst
@@ -1,0 +1,21 @@
+.. _contrib-index:
+
+#######################
+Contribution Guidelines
+#######################
+
+
+This section provides guidelines to contribute to the project through code, issues and documentation.
+
+
+.. toctree::
+   :maxdepth: 1
+   :titlesonly:
+
+   env.md
+   develop.md
+   coding.md
+   commit.md
+   pr.md
+   issues.md
+

--- a/docs/contrib/index.rst
+++ b/docs/contrib/index.rst
@@ -16,6 +16,6 @@ This section provides guidelines to contribute to the project through code, issu
    develop.md
    coding.md
    commit.md
-   pr.md
    issues.md
+   doc.md
 

--- a/docs/contrib/issues.md
+++ b/docs/contrib/issues.md
@@ -1,3 +1,14 @@
 # How to report issues
 
-Content to be added
+A bug report means something is broken, preventing normal/typical use of Rubix.
+
+Make sure the bug isn’t already resolved. Search for similar [issues](https://github.com/rubix/issues).
+
+Make sure you have clear instructions to reproduce your problem.
+
+If possible, submit a Pull Request with a failing test, or;  
+if you’d rather take matters into your own hands, try fix the bug yourself  
+Make a report of everything you know about the bug so far by opening an issue about it.  
+When the bug is fixed, you can usually expect to see an update posted on the reporting issue.  
+
+

--- a/docs/contrib/issues.md
+++ b/docs/contrib/issues.md
@@ -1,0 +1,3 @@
+# How to report issues
+
+Content to be added

--- a/docs/contrib/pr.md
+++ b/docs/contrib/pr.md
@@ -1,3 +1,0 @@
-# Pull Requests
-
-Content to be added

--- a/docs/contrib/pr.md
+++ b/docs/contrib/pr.md
@@ -1,0 +1,3 @@
+# Pull Requests
+
+Content to be added

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -17,7 +17,7 @@ Using the same plugins, RubiX can also be extended to be used with any cloud sto
    intro.md
    emr.md
    metrics.rst
-   contrib.md
+   contrib/index.rst
 
 Indices and tables
 ==================

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -16,7 +16,7 @@ Using the same plugins, RubiX can also be extended to be used with any cloud sto
 
    intro.md
    emr.md
-   metrics.md
+   metrics.rst
    contrib.md
 
 Indices and tables

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -1,7 +1,0 @@
-# Metrics
-
-These are the metrics currently available for RubiX.
-
-| RubiX Metric                    | Description                                                     |
-|---------------------------------|-----------------------------------------------------------------|
-| rubix.bookkeeper.liveness.gauge | Used to signal that the BookKeeper daemon is currently running. |

--- a/docs/metrics.rst
+++ b/docs/metrics.rst
@@ -1,0 +1,14 @@
+.. _metrics:
+
+=======
+Metrics
+=======
+
+These are the metrics currently available for RubiX.
+
++---------------------------------+-------------------------------------------+
+| RubiX Metric                    | Description                               |
++=================================+===========================================+
+| rubix.bookkeeper.liveness.gauge | Used to signal that the BookKeeper daemon |
+|                                 | is currently running.                     |
++---------------------------------+-------------------------------------------+


### PR DESCRIPTION
#130 

Add more details to contribution guide for code, issues, PR and documentation. Also
add a CONTRIBUTING.md. This file will be hyperlinked when some one opens an issue
or PR. Check https://help.github.com/articles/setting-guidelines-for-repository-contributors/. 
Heavily inspired by Discourse Guidelines: https://help.github.com/articles/setting-guidelines-for-repository-contributors/. This commit also makes a minor fix to metrics page. 