### PR TITLE
chg:usr:Add a CHANGELOG File

### DIFF
--- a/.gitchangelog.rc
+++ b/.gitchangelog.rc
@@ -1,0 +1,289 @@
+# -*- coding: utf-8; mode: python -*-
+##
+## Format
+##
+##   ACTION: [AUDIENCE:] COMMIT_MSG [!TAG ...]
+##
+## Description
+##
+##   ACTION is one of 'chg', 'fix', 'new'
+##
+##       Is WHAT the change is about.
+##
+##       'chg' is for refactor, small improvement, cosmetic changes...
+##       'fix' is for bug fixes
+##       'new' is for new features, big improvement
+##
+##   AUDIENCE is optional and one of 'dev', 'usr', 'pkg', 'test', 'doc'
+##
+##       Is WHO is concerned by the change.
+##
+##       'dev'  is for developpers (API changes, refactors...)
+##       'usr'  is for final users (UI changes)
+##       'pkg'  is for packagers   (packaging changes)
+##       'test' is for testers     (test only related changes)
+##       'doc'  is for doc guys    (doc only changes)
+##
+##   COMMIT_MSG is ... well ... the commit message itself.
+##
+##   TAGs are additionnal adjective as 'refactor' 'minor' 'cosmetic'
+##
+##       They are preceded with a '!' or a '@' (prefer the former, as the
+##       latter is wrongly interpreted in github.) Commonly used tags are:
+##
+##       'refactor' is obviously for refactoring code only
+##       'minor' is for a very meaningless change (a typo, adding a comment)
+##       'cosmetic' is for cosmetic driven change (re-indentation, 80-col...)
+##       'wip' is for partial functionality but complete subfunctionality.
+##
+## Example:
+##
+##   new: usr: support of bazaar implemented
+##   chg: re-indentend some lines !cosmetic
+##   new: dev: updated code to be compatible with last version of killer lib.
+##   fix: pkg: updated year of licence coverage.
+##   new: test: added a bunch of test around user usability of feature X.
+##   fix: typo in spelling my name in comment. !minor
+##
+##   Please note that multi-line commit message are supported, and only the
+##   first line will be considered as the "summary" of the commit message. So
+##   tags, and other rules only applies to the summary.  The body of the commit
+##   message will be displayed in the changelog without reformatting.
+
+
+##
+## ``ignore_regexps`` is a line of regexps
+##
+## Any commit having its full commit message matching any regexp listed here
+## will be ignored and won't be reported in the changelog.
+##
+ignore_regexps = [
+    r'@minor', r'!minor',
+    r'@cosmetic', r'!cosmetic',
+    r'@refactor', r'!refactor',
+    r'@wip', r'!wip',
+    r'^([cC]hg|[fF]ix|[nN]ew)\s*:\s*[p|P]kg:',
+    r'^([cC]hg|[fF]ix|[nN]ew)\s*:\s*[d|D]ev:',
+    r'^(.{3,3}\s*:)?\s*[fF]irst commit.?\s*$',
+    r'^$',  ## ignore commits with empty messages
+]
+
+
+## ``section_regexps`` is a list of 2-tuples associating a string label and a
+## list of regexp
+##
+## Commit messages will be classified in sections thanks to this. Section
+## titles are the label, and a commit is classified under this section if any
+## of the regexps associated is matching.
+##
+## Please note that ``section_regexps`` will only classify commits and won't
+## make any changes to the contents. So you'll probably want to go check
+## ``subject_process`` (or ``body_process``) to do some changes to the subject,
+## whenever you are tweaking this variable.
+##
+section_regexps = [
+    ('New', [
+        r'^[nN]ew\s*:\s*((dev|use?r|pkg|test|doc)\s*:\s*)?([^\n]*)$',
+     ]),
+    ('Changes', [
+        r'^[cC]hg\s*:\s*((dev|use?r|pkg|test|doc)\s*:\s*)?([^\n]*)$',
+     ]),
+    ('Fix', [
+        r'^[fF]ix\s*:\s*((dev|use?r|pkg|test|doc)\s*:\s*)?([^\n]*)$',
+     ]),
+
+    ('Other', None ## Match all lines
+     ),
+
+]
+
+
+## ``body_process`` is a callable
+##
+## This callable will be given the original body and result will
+## be used in the changelog.
+##
+## Available constructs are:
+##
+##   - any python callable that take one txt argument and return txt argument.
+##
+##   - ReSub(pattern, replacement): will apply regexp substitution.
+##
+##   - Indent(chars="  "): will indent the text with the prefix
+##     Please remember that template engines gets also to modify the text and
+##     will usually indent themselves the text if needed.
+##
+##   - Wrap(regexp=r"\n\n"): re-wrap text in separate paragraph to fill 80-Columns
+##
+##   - noop: do nothing
+##
+##   - ucfirst: ensure the first letter is uppercase.
+##     (usually used in the ``subject_process`` pipeline)
+##
+##   - final_dot: ensure text finishes with a dot
+##     (usually used in the ``subject_process`` pipeline)
+##
+##   - strip: remove any spaces before or after the content of the string
+##
+##   - SetIfEmpty(msg="No commit message."): will set the text to
+##     whatever given ``msg`` if the current text is empty.
+##
+## Additionally, you can `pipe` the provided filters, for instance:
+#body_process = Wrap(regexp=r'\n(?=\w+\s*:)') | Indent(chars="  ")
+#body_process = Wrap(regexp=r'\n(?=\w+\s*:)')
+#body_process = noop
+body_process = ReSub(r'((^|\n)[A-Z]\w+(-\w+)*: .*(\n\s+.*)*)+$', r'') | strip
+
+
+## ``subject_process`` is a callable
+##
+## This callable will be given the original subject and result will
+## be used in the changelog.
+##
+## Available constructs are those listed in ``body_process`` doc.
+subject_process = (strip |
+    ReSub(r'^([cC]hg|[fF]ix|[nN]ew)\s*:\s*((dev|use?r|pkg|test|doc)\s*:\s*)?([^\n@]*)(@[a-z]+\s+)*$', r'\4') |
+    SetIfEmpty("No commit message.") | ucfirst | final_dot)
+
+
+## ``tag_filter_regexp`` is a regexp
+##
+## Tags that will be used for the changelog must match this regexp.
+##
+tag_filter_regexp = r'^rubix-root-[0-9]+\.[0-9]+(\.[0-9]+)?$'
+
+
+## ``unreleased_version_label`` is a string or a callable that outputs a string
+##
+## This label will be used as the changelog Title of the last set of changes
+## between last valid tag and HEAD if any.
+unreleased_version_label = "(unreleased)"
+
+
+## ``output_engine`` is a callable
+##
+## This will change the output format of the generated changelog file
+##
+## Available choices are:
+##
+##   - rest_py
+##
+##        Legacy pure python engine, outputs ReSTructured text.
+##        This is the default.
+##
+##   - mustache(<template_name>)
+##
+##        Template name could be any of the available templates in
+##        ``templates/mustache/*.tpl``.
+##        Requires python package ``pystache``.
+##        Examples:
+##           - mustache("markdown")
+##           - mustache("restructuredtext")
+##
+##   - makotemplate(<template_name>)
+##
+##        Template name could be any of the available templates in
+##        ``templates/mako/*.tpl``.
+##        Requires python package ``mako``.
+##        Examples:
+##           - makotemplate("restructuredtext")
+##
+output_engine = rest_py
+#output_engine = mustache("restructuredtext")
+#output_engine = mustache("markdown")
+#output_engine = makotemplate("restructuredtext")
+
+
+## ``include_merge`` is a boolean
+##
+## This option tells git-log whether to include merge commits in the log.
+## The default is to include them.
+include_merge = True
+
+
+## ``log_encoding`` is a string identifier
+##
+## This option tells gitchangelog what encoding is outputed by ``git log``.
+## The default is to be clever about it: it checks ``git config`` for
+## ``i18n.logOutputEncoding``, and if not found will default to git's own
+## default: ``utf-8``.
+#log_encoding = 'utf-8'
+
+
+## ``publish`` is a callable
+##
+## Sets what ``gitchangelog`` should do with the output generated by
+## the output engine. ``publish`` is a callable taking one argument
+## that is an interator on lines from the output engine.
+##
+## Some helper callable are provided:
+##
+## Available choices are:
+##
+##   - stdout
+##
+##        Outputs directly to standard output
+##        (This is the default)
+##
+##   - FileInsertAtFirstRegexMatch(file, pattern, idx=lamda m: m.start())
+##
+##        Creates a callable that will parse given file for the given
+##        regex pattern and will insert the output in the file.
+##        ``idx`` is a callable that receive the matching object and
+##        must return a integer index point where to insert the
+##        the output in the file. Default is to return the position of
+##        the start of the matched string.
+##
+##   - FileRegexSubst(file, pattern, replace, flags)
+##
+##        Apply a replace inplace in the given file. Your regex pattern must
+##        take care of everything and might be more complex. Check the README
+##        for a complete copy-pastable example.
+##
+# publish = FileInsertIntoFirstRegexMatch(
+#     "CHANGELOG.rst",
+#     r'/(?P<rev>[0-9]+\.[0-9]+(\.[0-9]+)?)\s+\([0-9]+-[0-9]{2}-[0-9]{2}\)\n--+\n/',
+#     idx=lambda m: m.start(1)
+# )
+#publish = stdout
+
+
+## ``revs`` is a list of callable or a list of string
+##
+## callable will be called to resolve as strings and allow dynamical
+## computation of these. The result will be used as revisions for
+## gitchangelog (as if directly stated on the command line). This allows
+## to filter exaclty which commits will be read by gitchangelog.
+##
+## To get a full documentation on the format of these strings, please
+## refer to the ``git rev-list`` arguments. There are many examples.
+##
+## Using callables is especially useful, for instance, if you
+## are using gitchangelog to generate incrementally your changelog.
+##
+## Some helpers are provided, you can use them::
+##
+##   - FileFirstRegexMatch(file, pattern): will return a callable that will
+##     return the first string match for the given pattern in the given file.
+##     If you use named sub-patterns in your regex pattern, it'll output only
+##     the string matching the regex pattern named "rev".
+##
+##   - Caret(rev): will return the rev prefixed by a "^", which is a
+##     way to remove the given revision and all its ancestor.
+##
+## Please note that if you provide a rev-list on the command line, it'll
+## replace this value (which will then be ignored).
+##
+## If empty, then ``gitchangelog`` will act as it had to generate a full
+## changelog.
+##
+## The default is to use all commits to make the changelog.
+#revs = ["^1.0.3", ]
+#revs = [
+#    Caret(
+#        FileFirstRegexMatch(
+#            "CHANGELOG.rst",
+#            r"(?P<rev>[0-9]+\.[0-9]+(\.[0-9]+)?)\s+\([0-9]+-[0-9]{2}-[0-9]{2}\)\n--+\n")),
+#    "HEAD"
+#]
+revs = []

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,0 +1,183 @@
+Changelog
+=========
+
+
+(unreleased)
+------------
+
+New
+~~~
+- Add more details to Contribution Guide and a markdown file  (#145)
+  [Rajat Venkatesh]
+
+  Add more details to contribution guide for code, issues, PR and documentation. 
+  Also add a CONTRIBUTING.md. This file will be hyperlinked when some one opens
+  an issue or PR. Check https://help.github.com/articles/setting-guidelines-for-repository-contributors/.
+  Heavily inspired by Discourse Guidelines: https://help.github.com/articles/setting-guidelines-for-repository-contributors/. 
+  This commit also makes a minor fix to metrics page.
+
+  Fix #130
+
+
+0.3.1 (2018-05-22)
+-----------------------------
+
+New
+~~~
+- Clean up README. Open issues to move most of the contents to docs
+  (#133) [Rajat Venkatesh]
+
+  Initially README was the only source of documentation. We have recently
+  created a doc site on readthedocs.org. Therefore we can now organize the docs
+  in a better way there. As a first step, this commit cleans up README and opens
+  the following issues:
+  #126 #127 #128 #129 #130 #131 #132
+
+Changes
+~~~~~~~
+- Add strata talk to readme (#136) [Shubham Tagra]
+- Remove Hadoop1 module as it is not supported (#135) [Rajat Venkatesh]
+
+  Hadoop1 module was an experimental module to test with Hadoop 1 clusters.
+  It is not supported in production with QDS or outside. Remove code as Hadoop1
+  is not used anymore.
+
+Fix
+~~~
+- ISS-141: Throwing exception only when none of the parent directories
+  exists (#142) [Abhishek Das]
+
+Other
+~~~~~
+- #124: report liveness metric for BookKeeper daemon (#139) [Jordan Wilson]
+
+  Add a liveness gauge that the daemon is up & alive. Right now, this is a 
+  simple check that a thread (reporter to be added in a subsequent commit) 
+  is alive. In the future, this simple framework will be used to add more 
+  comprehensive health checks. Ref: #140
+
+- #115: add tests to rubix-hadoop2 module to match rubix-presto (#118) 
+  [Jordan Wilson]
+
+  Fix #115
+
+
+0.3.0 (2018-04-10)
+------------------
+
+New
+~~~
+- #88: Added support for NativeAzure file system (#91) [Abhishek Das]
+
+0.2.14 (2018-04-09)
+-------------------
+
+Fix
+~~~
+- #78: Reduce cache warm up time(#95) [Abhishek Das]
+
+Other
+~~~~~
+- #105: update Checkstyle configuration based on Airlift's checks (#106)
+  [Jordan Wilson]
+
+
+0.2.13 (2018-01-10)
+-------------------
+
+New
+~~~
+- Adding support for rubix scheme and populating filesystem counters
+  (#77) [abhishekdas99]
+- Implemented Hadoop Tool interface for Bookkeeper daemons (#84)
+  [abhishekdas99]
+
+Fix
+~~~
+- Using private ip to check the node index when it fails for hostname
+  (#90) [Abhishek Das]
+- Added option to install a specific RubiX version (#85) [abhishekdas99]
+
+Other
+~~~~~
+- Rubix support for EMR Presto (#81) [abhishekdas99]
+
+  * adding support for rubix in open source presto (emr)
+
+  * adding support for rubix in open source presto (emr)
+  Fix #80
+- Installation guide for EMR cluster with Open Source Presto(#82)
+  [abhishekdas99]
+
+  Document latest changes to rubix-admin to support open source Presto on EMR clusters.
+
+
+0.2.12 (2017-09-19)
+-------------------
+
+New
+~~~
+- #68:Add a basic documentation framework (#74) [Rajat Venkatesh]
+- Improve RPM package with configuration and scripts (#52) [Rajat Venkatesh]
+
+  This commit adds
+  * configuration files for bookkeeper and lds.
+  * Start/Stop scripts
+  * Sets up run, log and conf directories.
+  Tested using rubix-admin on Qubole clusters.
+- Adding spark changes to the documentation (#58) [arajagopal17]
+
+  Add steps to use Rubix with Spark.
+  Fix #56
+- Add a new module to generate rpm for rubix (#51) [Rajat Venkatesh]
+
+  Generate RPM with instructions in README. RPM is not generated
+  in default or release profile.
+
+  The RPM contents are:
+
+  /usr/lib/rubix/conf
+  /usr/lib/rubix/lib
+  /usr/lib/rubix/lib/rubix-bookkeeper-0.2.12-SNAPSHOT.jar
+  /usr/lib/rubix/lib/rubix-core-0.2.12-SNAPSHOT.jar
+  /usr/lib/rubix/lib/rubix-hadoop1-0.2.12-SNAPSHOT.jar
+  /usr/lib/rubix/lib/rubix-hadoop2-0.2.12-SNAPSHOT.jar
+  /usr/lib/rubix/lib/rubix-presto-0.2.12-SNAPSHOT.jar
+  /usr/lib/rubix/lib/rubix-rpm-0.2.12-SNAPSHOT.jar
+  /usr/lib/rubix/lib/rubix-spi-0.2.12-SNAPSHOT.jar
+  /usr/lib/rubix/logs
+
+  The content will evolve with installation code.
+
+Fix
+~~~
+- Adding base dir property to rubix-rpm (#60) [arajagopal17]
+
+  Fix #59
+
+Other
+~~~~~
+- Add contribution guideline to docs (#76) [Goden Yao]
+
+  Fix #75
+- EMR: move client config to independent file (#73) [Vamshi Pasunuru]
+
+  Whatever properties that are needed by rubix client can now be specified 
+  in pre-populated /etc/rubix/config.xml. Like in qubole, we dump req 
+  properties in this file during installation. This avoid the need for an 
+  explicit dependency on yarn config.
+
+  Tested in Qubole and EMR clusters.
+- Support for Presto on EMR (#69) [Vamshi Pasunuru]
+
+  Provides an alternative discovery of master ip through hadoop yarn variables.
+  Also contains changes in rubix-rpm to correctly configure rubix.
+- Adding support for HDFS for hadoop2 cluster (#71) [abhishekdas99]
+
+  * fix: usr: Adding support for Distributed File System as remote file system 
+    for hadoop2 clusters
+- Fixed styiling issues (#65) [abhishekdas99]
+- Lazy loading of FSDataInputStream (#49) [abhishekdas99]
+
+  fixes #47
+- Support for S3A FileSystem (#50) [abhishekdas99]


### PR DESCRIPTION
Create a new file to hold CHANGELOG. The changelog is generated using gitchangelog. 
The required RC file has been added in this commit as well. Instructions regarding commit 
message formats and to generate the CHANGELOG will be added in a subsequent commit.