### PR TITLE
fix: dev: #235: address test issues to try to fix Travis build failures

### DIFF
--- a/rubix-bookkeeper/src/test/java/com/qubole/rubix/bookkeeper/TestBookKeeperServer.java
+++ b/rubix-bookkeeper/src/test/java/com/qubole/rubix/bookkeeper/TestBookKeeperServer.java
@@ -61,6 +61,7 @@ public class TestBookKeeperServer extends BaseServerTest
   public void setUp()
   {
     CacheConfig.setCacheDataDirPrefix(conf, TEST_CACHE_DIR_PREFIX);
+    CacheConfig.setMaxDisks(conf, TEST_MAX_DISKS);
 
     metrics = new MetricRegistry();
   }

--- a/rubix-bookkeeper/src/test/java/com/qubole/rubix/bookkeeper/TestHeartbeatService.java
+++ b/rubix-bookkeeper/src/test/java/com/qubole/rubix/bookkeeper/TestHeartbeatService.java
@@ -41,9 +41,9 @@ import static org.testng.Assert.assertNull;
 
 public class TestHeartbeatService
 {
-  private static final Log log = LogFactory.getLog(TestWorkerBookKeeper.class);
+  private static final Log log = LogFactory.getLog(TestHeartbeatService.class);
 
-  private static final String TEST_CACHE_DIR_PREFIX = TestUtil.getTestCacheDirPrefix("TestWorkerBookKeeper");
+  private static final String TEST_CACHE_DIR_PREFIX = TestUtil.getTestCacheDirPrefix("TestHeartbeatService");
   private static final int TEST_MAX_DISKS = 1;
   private static final int TEST_MAX_RETRIES = 5;
   private static final int TEST_RETRY_INTERVAL = 500;

--- a/rubix-bookkeeper/src/test/java/com/qubole/rubix/bookkeeper/TestHeartbeatService.java
+++ b/rubix-bookkeeper/src/test/java/com/qubole/rubix/bookkeeper/TestHeartbeatService.java
@@ -63,6 +63,7 @@ public class TestHeartbeatService
   public void setUp() throws InterruptedException
   {
     CacheConfig.setCacheDataDirPrefix(conf, TEST_CACHE_DIR_PREFIX);
+    CacheConfig.setMaxDisks(conf, TEST_MAX_DISKS);
     CacheConfig.setServiceRetryInterval(conf, TEST_RETRY_INTERVAL);
     CacheConfig.setHeartbeatInterval(conf, TEST_RETRY_INTERVAL);
     CacheConfig.setServiceMaxRetries(conf, TEST_MAX_RETRIES);

--- a/rubix-bookkeeper/src/test/java/com/qubole/rubix/bookkeeper/validation/TestCachingValidator.java
+++ b/rubix-bookkeeper/src/test/java/com/qubole/rubix/bookkeeper/validation/TestCachingValidator.java
@@ -63,7 +63,7 @@ public class TestCachingValidator
   public void setUp() throws IOException
   {
     CacheConfig.setCacheDataDirPrefix(conf, TEST_CACHE_DIR_PREFIX);
-    CacheConfig.setMaxDisks(conf, 1);
+    CacheConfig.setMaxDisks(conf, TEST_MAX_DISKS);
 
     TestUtil.createCacheParentDirectories(conf, TEST_MAX_DISKS);
   }

--- a/rubix-bookkeeper/src/test/java/com/qubole/rubix/bookkeeper/validation/TestCachingValidator.java
+++ b/rubix-bookkeeper/src/test/java/com/qubole/rubix/bookkeeper/validation/TestCachingValidator.java
@@ -69,8 +69,10 @@ public class TestCachingValidator
   }
 
   @AfterMethod
-  public void tearDown()
+  public void tearDown() throws IOException
   {
+    TestUtil.removeCacheParentDirectories(conf, TEST_MAX_DISKS);
+
     conf.clear();
   }
 

--- a/rubix-bookkeeper/src/test/java/com/qubole/rubix/bookkeeper/validation/TestCachingValidator.java
+++ b/rubix-bookkeeper/src/test/java/com/qubole/rubix/bookkeeper/validation/TestCachingValidator.java
@@ -71,6 +71,7 @@ public class TestCachingValidator
   @AfterMethod
   public void tearDown() throws IOException
   {
+    CacheConfig.setCacheDataDirPrefix(conf, TEST_CACHE_DIR_PREFIX);
     TestUtil.removeCacheParentDirectories(conf, TEST_MAX_DISKS);
 
     conf.clear();

--- a/rubix-bookkeeper/src/test/java/com/qubole/rubix/bookkeeper/validation/TestCachingValidator.java
+++ b/rubix-bookkeeper/src/test/java/com/qubole/rubix/bookkeeper/validation/TestCachingValidator.java
@@ -16,6 +16,7 @@ import com.codahale.metrics.MetricRegistry;
 import com.google.common.collect.Lists;
 import com.qubole.rubix.bookkeeper.BookKeeper;
 import com.qubole.rubix.bookkeeper.CoordinatorBookKeeper;
+import com.qubole.rubix.common.TestUtil;
 import com.qubole.rubix.common.metrics.BookKeeperMetrics;
 import com.qubole.rubix.spi.BookKeeperFactory;
 import com.qubole.rubix.spi.CacheConfig;
@@ -34,6 +35,7 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import java.io.FileNotFoundException;
+import java.io.IOException;
 import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -48,6 +50,8 @@ public class TestCachingValidator
 {
   private static final Log log = LogFactory.getLog(TestCachingValidator.class);
 
+  private static final String TEST_CACHE_DIR_PREFIX = TestUtil.getTestCacheDirPrefix("TestCachingValidator");
+  private static final int TEST_MAX_DISKS = 1;
   private static final int TEST_VALIDATION_INTERVAL = 1000; // ms
   private static final String TEST_REMOTE_LOCATION = "testLocation";
   private static final List<BlockLocation> TEST_LOCATIONS_CACHED = Lists.newArrayList(new BlockLocation(Location.CACHED, TEST_REMOTE_LOCATION));
@@ -56,8 +60,12 @@ public class TestCachingValidator
   private final Configuration conf = new Configuration();
 
   @BeforeMethod
-  public void setUp()
+  public void setUp() throws IOException
   {
+    CacheConfig.setCacheDataDirPrefix(conf, TEST_CACHE_DIR_PREFIX);
+    CacheConfig.setMaxDisks(conf, 1);
+
+    TestUtil.createCacheParentDirectories(conf, TEST_MAX_DISKS);
   }
 
   @AfterMethod


### PR DESCRIPTION
Addressing some issues discovered in the Travis build logs which might be affecting the success of other tests:
- FileValidator trying to validate cache directory with "null" prefix
- Prefix not correctly set for CachingValidator tests