### PR TITLE
fix: dev: #243: Schedule validators on same thread to avoid overlap

### DIFF
--- a/rubix-bookkeeper/src/main/java/com/qubole/rubix/bookkeeper/HeartbeatService.java
+++ b/rubix-bookkeeper/src/main/java/com/qubole/rubix/bookkeeper/HeartbeatService.java
@@ -15,6 +15,7 @@ package com.qubole.rubix.bookkeeper;
 import com.codahale.metrics.Gauge;
 import com.codahale.metrics.MetricRegistry;
 import com.google.common.util.concurrent.AbstractScheduledService;
+import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.Service;
 import com.qubole.rubix.bookkeeper.validation.CachingValidator;
 import com.qubole.rubix.bookkeeper.validation.FileValidator;
@@ -32,8 +33,8 @@ import org.apache.thrift.shaded.transport.TTransportException;
 
 import java.io.IOException;
 import java.net.InetAddress;
-import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
 public class HeartbeatService extends AbstractScheduledService
@@ -41,7 +42,7 @@ public class HeartbeatService extends AbstractScheduledService
   private Log log = LogFactory.getLog(HeartbeatService.class.getName());
 
   // The executor used for running listener callbacks.
-  private final Executor executor = Executors.newSingleThreadExecutor();
+  private final ScheduledExecutorService validatorExecutor = Executors.newSingleThreadScheduledExecutor();
 
   // The client for interacting with the master BookKeeper.
   private final RetryingBookkeeperClient bookkeeperClient;
@@ -74,7 +75,7 @@ public class HeartbeatService extends AbstractScheduledService
     this.bookkeeperClient = initializeClientWithRetry(bookKeeperFactory);
 
     if (CacheConfig.isValidationEnabled(conf)) {
-      this.cachingValidator = new CachingValidator(conf, bookKeeper);
+      this.cachingValidator = new CachingValidator(conf, bookKeeper, validatorExecutor);
       this.cachingValidator.startAsync();
       metrics.register(BookKeeperMetrics.ValidationMetric.CACHING_VALIDATION_SUCCESS_GAUGE.getMetricName(), new Gauge<Integer>()
       {
@@ -85,7 +86,7 @@ public class HeartbeatService extends AbstractScheduledService
         }
       });
 
-      this.fileValidator = new FileValidator(conf);
+      this.fileValidator = new FileValidator(conf, validatorExecutor);
       this.fileValidator.startAsync();
       metrics.register(BookKeeperMetrics.ValidationMetric.FILE_VALIDATION_SUCCESS_GAUGE.getMetricName(), new Gauge<Integer>()
       {
@@ -139,7 +140,7 @@ public class HeartbeatService extends AbstractScheduledService
   protected void startUp()
   {
     log.info(String.format("Starting service %s in thread %d", serviceName(), Thread.currentThread().getId()));
-    addListener(new HeartbeatService.FailureListener(), executor);
+    addListener(new HeartbeatService.FailureListener(), MoreExecutors.directExecutor());
   }
 
   @Override

--- a/rubix-bookkeeper/src/main/java/com/qubole/rubix/bookkeeper/validation/CachingValidator.java
+++ b/rubix-bookkeeper/src/main/java/com/qubole/rubix/bookkeeper/validation/CachingValidator.java
@@ -30,6 +30,7 @@ import org.apache.thrift.shaded.TException;
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -52,14 +53,22 @@ public class CachingValidator extends AbstractScheduledService
   private static final int VALIDATOR_CLUSTER_TYPE = ClusterType.TEST_CLUSTER_MANAGER.ordinal();
 
   private final BookKeeper bookKeeper;
+  private final ScheduledExecutorService validationExecutor;
   private final int cachingValidationInterval;
 
   private AtomicBoolean validationSuccess = new AtomicBoolean(true);
 
-  public CachingValidator(Configuration conf, BookKeeper bookKeeper)
+  public CachingValidator(Configuration conf, BookKeeper bookKeeper, ScheduledExecutorService validationExecutor)
   {
     this.bookKeeper = bookKeeper;
+    this.validationExecutor = validationExecutor;
     this.cachingValidationInterval = CacheConfig.getCachingValidationInterval(conf);
+  }
+
+  @Override
+  protected ScheduledExecutorService executor()
+  {
+    return validationExecutor;
   }
 
   @Override

--- a/rubix-bookkeeper/src/main/java/com/qubole/rubix/bookkeeper/validation/FileValidator.java
+++ b/rubix-bookkeeper/src/main/java/com/qubole/rubix/bookkeeper/validation/FileValidator.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
 public class FileValidator extends AbstractScheduledService
@@ -30,14 +31,22 @@ public class FileValidator extends AbstractScheduledService
   private static final Log log = LogFactory.getLog(FileValidator.class);
 
   private final Configuration conf;
+  private final ScheduledExecutorService validationExecutor;
   private final int validationInterval;
 
   private FileValidatorResult validatorResult = new FileValidatorResult();
 
-  public FileValidator(Configuration conf)
+  public FileValidator(Configuration conf, ScheduledExecutorService validationExecutor)
   {
     this.conf = conf;
+    this.validationExecutor = validationExecutor;
     this.validationInterval = CacheConfig.getCachingValidationInterval(conf);
+  }
+
+  @Override
+  protected ScheduledExecutorService executor()
+  {
+    return validationExecutor;
   }
 
   @Override

--- a/rubix-bookkeeper/src/test/java/com/qubole/rubix/bookkeeper/validation/TestCachingValidator.java
+++ b/rubix-bookkeeper/src/test/java/com/qubole/rubix/bookkeeper/validation/TestCachingValidator.java
@@ -16,6 +16,7 @@ import com.codahale.metrics.MetricRegistry;
 import com.google.common.collect.Lists;
 import com.qubole.rubix.bookkeeper.BookKeeper;
 import com.qubole.rubix.bookkeeper.CoordinatorBookKeeper;
+import com.qubole.rubix.common.TestUtil;
 import com.qubole.rubix.common.metrics.BookKeeperMetrics;
 import com.qubole.rubix.spi.BookKeeperFactory;
 import com.qubole.rubix.spi.CacheConfig;
@@ -34,7 +35,9 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import java.io.FileNotFoundException;
+import java.io.IOException;
 import java.util.List;
+import java.util.concurrent.Executors;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -48,6 +51,8 @@ public class TestCachingValidator
 {
   private static final Log log = LogFactory.getLog(TestCachingValidator.class);
 
+  private static final String TEST_CACHE_DIR_PREFIX = TestUtil.getTestCacheDirPrefix("TestCachingValidator");
+  private static final int TEST_MAX_DISKS = 1;
   private static final int TEST_VALIDATION_INTERVAL = 1000; // ms
   private static final String TEST_REMOTE_LOCATION = "testLocation";
   private static final List<BlockLocation> TEST_LOCATIONS_CACHED = Lists.newArrayList(new BlockLocation(Location.CACHED, TEST_REMOTE_LOCATION));
@@ -56,13 +61,20 @@ public class TestCachingValidator
   private final Configuration conf = new Configuration();
 
   @BeforeMethod
-  public void setUp()
+  public void setUp() throws IOException
   {
+    CacheConfig.setCacheDataDirPrefix(conf, TEST_CACHE_DIR_PREFIX);
+    CacheConfig.setMaxDisks(conf, TEST_MAX_DISKS);
+
+    TestUtil.createCacheParentDirectories(conf, TEST_MAX_DISKS);
   }
 
   @AfterMethod
-  public void tearDown()
+  public void tearDown() throws IOException
   {
+    CacheConfig.setCacheDataDirPrefix(conf, TEST_CACHE_DIR_PREFIX);
+    TestUtil.removeCacheParentDirectories(conf, TEST_MAX_DISKS);
+
     conf.clear();
   }
 
@@ -184,7 +196,7 @@ public class TestCachingValidator
             new TSocket("localhost", CacheConfig.getServerPort(conf), CacheConfig.getClientTimeout(conf)),
             CacheConfig.getMaxRetries(conf)));
 
-    CachingValidator validator = new CachingValidator(conf, bookKeeper);
+    CachingValidator validator = new CachingValidator(conf, bookKeeper, Executors.newSingleThreadScheduledExecutor());
     assertEquals(validator.validateCachingBehavior(), expectedResult);
   }
 }


### PR DESCRIPTION
By supplying the same single-threaded executor to both validators, each validator will still be correctly scheduled, but will no longer be running concurrently with another validation.