### PR TITLE
fix: dev: #186: use appropriate Cobertura goal to shade jars before testing

### DIFF
--- a/script.sh
+++ b/script.sh
@@ -23,5 +23,5 @@ mvn clean install
 if [[ $? -ne 0 ]]; then
     exit 1
 fi
-mvn cobertura:cobertura
+mvn cobertura:cobertura-integration-test
 bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
`mvn cobertura:cobertura-integration-test` runs the `verify` phase, which includes the `package` phase needed to shade the JARs for tests in later modules. This means that the `bookkeeper` tests should now all pass and report the correct coverage.