### PR TITLE
chg: dev: Created a ReadRequestChainFactory to instantiate all RRCs from a single location

### DIFF
--- a/rubix-bookkeeper/src/main/java/com/qubole/rubix/bookkeeper/BookKeeper.java
+++ b/rubix-bookkeeper/src/main/java/com/qubole/rubix/bookkeeper/BookKeeper.java
@@ -31,6 +31,7 @@ import com.qubole.rubix.bookkeeper.validation.CachingValidator;
 import com.qubole.rubix.common.metrics.BookKeeperMetrics;
 import com.qubole.rubix.core.ClusterManagerInitilizationException;
 import com.qubole.rubix.core.ReadRequest;
+import com.qubole.rubix.core.ReadRequestChainFactory;
 import com.qubole.rubix.core.RemoteReadRequestChain;
 import com.qubole.rubix.spi.BookKeeperFactory;
 import com.qubole.rubix.spi.CacheConfig;
@@ -522,7 +523,7 @@ public abstract class BookKeeper implements BookKeeperService.Iface
           // Ue RRRC directly instead of creating instance of CachingFS as in certain circumstances, CachingFS could
           // send this request to NonLocalRRC which would be wrong as that would not cache it on disk
           long expectedBytesToRead = (readStart + blockSize) > fileSize ? (fileSize - readStart) : blockSize;
-          RemoteReadRequestChain remoteReadRequestChain = new RemoteReadRequestChain(inputStream, localPath, byteBuffer, buffer, new BookKeeperFactory(this));
+          RemoteReadRequestChain remoteReadRequestChain = ReadRequestChainFactory.createReadRequestChain(RemoteReadRequestChain.class, inputStream, localPath, byteBuffer, buffer, new BookKeeperFactory(this));
           remoteReadRequestChain.addReadRequest(new ReadRequest(readStart, readStart + blockSize, readStart, readStart + blockSize, buffer, 0, fileSize));
           remoteReadRequestChain.lock();
           Integer dataRead = remoteReadRequestChain.call();

--- a/rubix-bookkeeper/src/main/java/com/qubole/rubix/bookkeeper/BookKeeper.java
+++ b/rubix-bookkeeper/src/main/java/com/qubole/rubix/bookkeeper/BookKeeper.java
@@ -523,7 +523,7 @@ public abstract class BookKeeper implements BookKeeperService.Iface
           // Ue RRRC directly instead of creating instance of CachingFS as in certain circumstances, CachingFS could
           // send this request to NonLocalRRC which would be wrong as that would not cache it on disk
           long expectedBytesToRead = (readStart + blockSize) > fileSize ? (fileSize - readStart) : blockSize;
-          RemoteReadRequestChain remoteReadRequestChain = ReadRequestChainFactory.createReadRequestChain(RemoteReadRequestChain.class, inputStream, localPath, byteBuffer, buffer, new BookKeeperFactory(this));
+          RemoteReadRequestChain remoteReadRequestChain = ReadRequestChainFactory.createRemoteReadRequestChain(inputStream, localPath, byteBuffer, buffer, new BookKeeperFactory(this));
           remoteReadRequestChain.addReadRequest(new ReadRequest(readStart, readStart + blockSize, readStart, readStart + blockSize, buffer, 0, fileSize));
           remoteReadRequestChain.lock();
           Integer dataRead = remoteReadRequestChain.call();

--- a/rubix-bookkeeper/src/main/java/com/qubole/rubix/bookkeeper/FileDownloader.java
+++ b/rubix-bookkeeper/src/main/java/com/qubole/rubix/bookkeeper/FileDownloader.java
@@ -26,7 +26,7 @@ import com.qubole.rubix.core.ReadRequestChainFactory;
 import com.qubole.rubix.spi.BookKeeperFactory;
 import com.qubole.rubix.spi.CacheConfig;
 import com.qubole.rubix.spi.CacheUtil;
-import com.qubole.rubix.spi.thrift.BookKeeperService;
+import com.qubole.rubix.spi.RetryingBookkeeperClient;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.conf.Configuration;
@@ -100,14 +100,14 @@ class FileDownloader
       log.info("Processing Request for File : " + path.toString() + " LocalFile : " + localPath);
       ByteBuffer directWriteBuffer = bufferPool.getBuffer(diskReadBufferSize);
 
-      BookKeeperService.Client bookKeeperClient = null;
+      RetryingBookkeeperClient bookKeeperClient = null;
       try {
         bookKeeperClient = new BookKeeperFactory(bookKeeper).createBookKeeperClient(conf);
       }
       catch (TTransportException e) {
         Throwables.propagate(e);
       }
-      FileDownloadRequestChain requestChain = ReadRequestChainFactory.createReadRequestChain(FileDownloadRequestChain.class, bookKeeperClient, fs, localPath,
+      FileDownloadRequestChain requestChain = ReadRequestChainFactory.createFileDownloadRequestChain(bookKeeperClient, fs, localPath,
           directWriteBuffer, conf, context.getRemoteFilePath(), context.getFileSize(), context.getLastModifiedTime());
 
       for (Range<Long> range : context.getRanges().asRanges()) {

--- a/rubix-bookkeeper/src/main/java/com/qubole/rubix/bookkeeper/RemoteFetchProcessor.java
+++ b/rubix-bookkeeper/src/main/java/com/qubole/rubix/bookkeeper/RemoteFetchProcessor.java
@@ -17,6 +17,7 @@ import com.codahale.metrics.Gauge;
 import com.codahale.metrics.MetricRegistry;
 import com.google.common.util.concurrent.AbstractScheduledService;
 import com.qubole.rubix.common.metrics.BookKeeperMetrics;
+import com.qubole.rubix.core.FileDownloadRequestChain;
 import com.qubole.rubix.spi.CacheConfig;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;

--- a/rubix-bookkeeper/src/test/java/com/qubole/rubix/bookkeeper/TestFileDownloader.java
+++ b/rubix-bookkeeper/src/test/java/com/qubole/rubix/bookkeeper/TestFileDownloader.java
@@ -18,6 +18,7 @@ import com.qubole.rubix.bookkeeper.utils.DiskUtils;
 import com.qubole.rubix.common.metrics.BookKeeperMetrics;
 import com.qubole.rubix.common.utils.DataGen;
 import com.qubole.rubix.common.utils.TestUtil;
+import com.qubole.rubix.core.FileDownloadRequestChain;
 import com.qubole.rubix.spi.CacheConfig;
 import com.qubole.rubix.spi.CacheUtil;
 import com.qubole.rubix.spi.ClusterType;

--- a/rubix-core/src/main/java/com/qubole/rubix/core/CachedReadRequestChain.java
+++ b/rubix-core/src/main/java/com/qubole/rubix/core/CachedReadRequestChain.java
@@ -205,7 +205,7 @@ public class CachedReadRequestChain extends ReadRequestChain
     read = 0;
 
     FSDataInputStream inputStream = remoteFileSystem.open(new Path(remotePath));
-    directReadChain = new DirectReadRequestChain(inputStream);
+    directReadChain = ReadRequestChainFactory.createReadRequestChain(DirectReadRequestChain.class, inputStream);
     for (ReadRequest readRequest : readRequests) {
       directReadChain.addReadRequest(readRequest);
     }

--- a/rubix-core/src/main/java/com/qubole/rubix/core/CachedReadRequestChain.java
+++ b/rubix-core/src/main/java/com/qubole/rubix/core/CachedReadRequestChain.java
@@ -205,7 +205,7 @@ public class CachedReadRequestChain extends ReadRequestChain
     read = 0;
 
     FSDataInputStream inputStream = remoteFileSystem.open(new Path(remotePath));
-    directReadChain = ReadRequestChainFactory.createReadRequestChain(DirectReadRequestChain.class, inputStream);
+    directReadChain = ReadRequestChainFactory.createDirectReadRequestChain(inputStream);
     for (ReadRequest readRequest : readRequests) {
       directReadChain.addReadRequest(readRequest);
     }

--- a/rubix-core/src/main/java/com/qubole/rubix/core/NonLocalReadRequestChain.java
+++ b/rubix-core/src/main/java/com/qubole/rubix/core/NonLocalReadRequestChain.java
@@ -183,7 +183,7 @@ public class NonLocalReadRequestChain extends ReadRequestChain
       throws Exception
   {
     FSDataInputStream inputStream = remoteFileSystem.open(new Path(filePath));
-    directReadChain = new DirectReadRequestChain(inputStream);
+    directReadChain = ReadRequestChainFactory.createReadRequestChain(DirectReadRequestChain.class, inputStream);
     for (ReadRequest readRequest : readRequests.subList(index, readRequests.size())) {
       directReadChain.addReadRequest(readRequest);
     }

--- a/rubix-core/src/main/java/com/qubole/rubix/core/NonLocalReadRequestChain.java
+++ b/rubix-core/src/main/java/com/qubole/rubix/core/NonLocalReadRequestChain.java
@@ -183,7 +183,7 @@ public class NonLocalReadRequestChain extends ReadRequestChain
       throws Exception
   {
     FSDataInputStream inputStream = remoteFileSystem.open(new Path(filePath));
-    directReadChain = ReadRequestChainFactory.createReadRequestChain(DirectReadRequestChain.class, inputStream);
+    directReadChain = ReadRequestChainFactory.createDirectReadRequestChain(inputStream);
     for (ReadRequest readRequest : readRequests.subList(index, readRequests.size())) {
       directReadChain.addReadRequest(readRequest);
     }

--- a/rubix-core/src/main/java/com/qubole/rubix/core/NonLocalRequestChain.java
+++ b/rubix-core/src/main/java/com/qubole/rubix/core/NonLocalRequestChain.java
@@ -115,16 +115,16 @@ public class NonLocalRequestChain extends ReadRequestChain
     if (!needDirectReadRequest(blockNum)) {
       needDirectReadRequest = false;
       if (nonLocalReadRequestChain == null) {
-        nonLocalReadRequestChain = ReadRequestChainFactory.createReadRequestChain(NonLocalReadRequestChain.class, remoteNodeName, fileSize, lastModified, conf,
-            remoteFileSystem, remoteFilePath, clusterType, strictMode, statistics, 0, 0);
+        nonLocalReadRequestChain = ReadRequestChainFactory.createNonLocalReadRequestChain(remoteNodeName, fileSize, lastModified, conf,
+            remoteFileSystem, remoteFilePath, clusterType, strictMode, statistics);
       }
       nonLocalReadRequestChain.addReadRequest(readRequest);
     }
     else {
       needDirectReadRequest = true;
       if (remoteFetchRequestChain == null) {
-        remoteFetchRequestChain = ReadRequestChainFactory.createReadRequestChain(RemoteFetchRequestChain.class, remoteNodeName, fileSize, lastModified, conf,
-                remoteFileSystem, remoteFilePath, clusterType, false, null, 0, 0);
+        remoteFetchRequestChain = ReadRequestChainFactory.createRemoteFetchRequestChain(remoteNodeName, fileSize, lastModified, conf,
+                remoteFileSystem, remoteFilePath, clusterType);
       }
       remoteFetchRequestChain.addReadRequest(readRequest);
     }

--- a/rubix-core/src/main/java/com/qubole/rubix/core/NonLocalRequestChain.java
+++ b/rubix-core/src/main/java/com/qubole/rubix/core/NonLocalRequestChain.java
@@ -115,16 +115,16 @@ public class NonLocalRequestChain extends ReadRequestChain
     if (!needDirectReadRequest(blockNum)) {
       needDirectReadRequest = false;
       if (nonLocalReadRequestChain == null) {
-        nonLocalReadRequestChain = new NonLocalReadRequestChain(remoteNodeName, fileSize, lastModified, conf,
-            remoteFileSystem, remoteFilePath, clusterType, strictMode, statistics);
+        nonLocalReadRequestChain = ReadRequestChainFactory.createReadRequestChain(NonLocalReadRequestChain.class, remoteNodeName, fileSize, lastModified, conf,
+            remoteFileSystem, remoteFilePath, clusterType, strictMode, statistics, 0, 0);
       }
       nonLocalReadRequestChain.addReadRequest(readRequest);
     }
     else {
       needDirectReadRequest = true;
       if (remoteFetchRequestChain == null) {
-        remoteFetchRequestChain = new RemoteFetchRequestChain(remoteFilePath, remoteFileSystem, remoteNodeName,
-            conf, lastModified, fileSize, clusterType);
+        remoteFetchRequestChain = ReadRequestChainFactory.createReadRequestChain(RemoteFetchRequestChain.class, remoteNodeName, fileSize, lastModified, conf,
+                remoteFileSystem, remoteFilePath, clusterType, false, null, 0, 0);
       }
       remoteFetchRequestChain.addReadRequest(readRequest);
     }

--- a/rubix-core/src/main/java/com/qubole/rubix/core/ReadRequestChainFactory.java
+++ b/rubix-core/src/main/java/com/qubole/rubix/core/ReadRequestChainFactory.java
@@ -1,0 +1,82 @@
+/**
+ * Copyright (c) 2019. Qubole Inc
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License. See accompanying LICENSE file.
+ */
+package com.qubole.rubix.core;
+
+import com.qubole.rubix.spi.BookKeeperFactory;
+import com.qubole.rubix.spi.thrift.BookKeeperService;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.FileSystem;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+public final class ReadRequestChainFactory
+{
+  private ReadRequestChainFactory()
+  { }
+
+  public static <T extends ReadRequestChain> T createReadRequestChain(Class<T> readRequestChainType, FSDataInputStream inputStream)
+  {
+    if (readRequestChainType == DirectReadRequestChain.class) {
+      return readRequestChainType.cast(new DirectReadRequestChain(inputStream));
+    }
+    throw new IllegalArgumentException("The type of ReadRequestChain: " + readRequestChainType.getName() + " does not match the arguments or is unknown");
+  }
+
+  public static <T extends ReadRequestChain> T createReadRequestChain(Class<T> readRequestChainType, FileSystem remoteFileSystem, String remotePath, ByteBuffer buffer,
+                                                               FileSystem.Statistics statistics, Configuration conf, BookKeeperFactory bookKeeperFactory) throws IOException
+  {
+    if (readRequestChainType == CachedReadRequestChain.class) {
+      return readRequestChainType.cast(new CachedReadRequestChain(remoteFileSystem, remotePath, buffer, statistics, conf, bookKeeperFactory));
+    }
+    throw new IllegalArgumentException("The type of ReadRequestChain: " + readRequestChainType.getName() + " does not match the arguments or is unknown");
+  }
+
+  public static <T extends ReadRequestChain> T createReadRequestChain(Class<T> readRequestChainType, String remoteLocation, long fileSize, long lastModified, Configuration conf,
+                                                               FileSystem remoteFileSystem, String remotePath, int clusterType,
+                                                               boolean strictMode, FileSystem.Statistics statistics, long startBlock, long endBlock)
+  {
+    if (readRequestChainType == NonLocalReadRequestChain.class) {
+      return readRequestChainType.cast(new NonLocalReadRequestChain(remoteLocation, fileSize, lastModified, conf, remoteFileSystem, remotePath, clusterType, strictMode, statistics));
+    }
+    else if (readRequestChainType == NonLocalRequestChain.class) {
+      return readRequestChainType.cast(new NonLocalRequestChain(remoteLocation, fileSize, lastModified, conf, remoteFileSystem, remotePath, clusterType, strictMode, statistics, startBlock, endBlock));
+    }
+    else if (readRequestChainType == RemoteFetchRequestChain.class) {
+      return readRequestChainType.cast(new RemoteFetchRequestChain(remotePath, remoteFileSystem, remoteLocation, conf, lastModified, fileSize, clusterType));
+    }
+    throw new IllegalArgumentException("The type of ReadRequestChain: " + readRequestChainType.getName() + " does not match the arguments or is unknown");
+  }
+
+  public static <T extends ReadRequestChain> T createReadRequestChain(Class<T> readRequestChainType, FSDataInputStream inputStream, String localfile, ByteBuffer directBuffer, byte[] affixBuffer, BookKeeperFactory bookKeeperFactory) throws IOException
+  {
+    if (readRequestChainType == RemoteReadRequestChain.class) {
+      if (bookKeeperFactory == null) {
+        bookKeeperFactory = new BookKeeperFactory();
+      }
+      return readRequestChainType.cast(new RemoteReadRequestChain(inputStream, localfile, directBuffer, affixBuffer, bookKeeperFactory));
+    }
+    throw new IllegalArgumentException("The type of ReadRequestChain: " + readRequestChainType.getName() + " does not match the arguments or is unknown");
+  }
+
+  public static <T extends ReadRequestChain> T createReadRequestChain(Class<T> readRequestChainType, BookKeeperService.Client bookKeeperClient, FileSystem remoteFileSystem, String localfile,
+                                                               ByteBuffer directBuffer, Configuration conf, String remotePath,
+                                                               long fileSize, long lastModified)
+  {
+    if (readRequestChainType == FileDownloadRequestChain.class) {
+      return readRequestChainType.cast(new FileDownloadRequestChain(bookKeeperClient, remoteFileSystem, localfile, directBuffer, conf, remotePath, fileSize, lastModified));
+    }
+    throw new IllegalArgumentException("The type of ReadRequestChain: " + readRequestChainType.getName() + " does not match the arguments or is unknown");
+  }
+}

--- a/rubix-core/src/main/java/com/qubole/rubix/core/ReadRequestChainFactory.java
+++ b/rubix-core/src/main/java/com/qubole/rubix/core/ReadRequestChainFactory.java
@@ -26,57 +26,89 @@ public final class ReadRequestChainFactory
   private ReadRequestChainFactory()
   { }
 
-  public static <T extends ReadRequestChain> T createReadRequestChain(Class<T> readRequestChainType, FSDataInputStream inputStream)
+  public static DirectReadRequestChain createDirectReadRequestChain(FSDataInputStream inputStream)
   {
-    if (readRequestChainType == DirectReadRequestChain.class) {
-      return readRequestChainType.cast(new DirectReadRequestChain(inputStream));
-    }
-    throw new IllegalArgumentException("The type of ReadRequestChain: " + readRequestChainType.getName() + " does not match the arguments or is unknown");
+    return new DirectReadRequestChain(inputStream);
   }
 
-  public static <T extends ReadRequestChain> T createReadRequestChain(Class<T> readRequestChainType, FileSystem remoteFileSystem, String remotePath, ByteBuffer buffer,
-                                                               FileSystem.Statistics statistics, Configuration conf, BookKeeperFactory bookKeeperFactory) throws IOException
+  public static CachedReadRequestChain createCachedReadRequestChain(FileSystem remoteFileSystem,
+                                                                    String remotePath,
+                                                                    ByteBuffer buffer,
+                                                                    FileSystem.Statistics statistics,
+                                                                    Configuration conf,
+                                                                    BookKeeperFactory bookKeeperFactory)
+          throws IOException
   {
-    if (readRequestChainType == CachedReadRequestChain.class) {
-      return readRequestChainType.cast(new CachedReadRequestChain(remoteFileSystem, remotePath, buffer, statistics, conf, bookKeeperFactory));
-    }
-    throw new IllegalArgumentException("The type of ReadRequestChain: " + readRequestChainType.getName() + " does not match the arguments or is unknown");
+    return new CachedReadRequestChain(remoteFileSystem, remotePath, buffer, statistics, conf, bookKeeperFactory);
   }
 
-  public static <T extends ReadRequestChain> T createReadRequestChain(Class<T> readRequestChainType, String remoteLocation, long fileSize, long lastModified, Configuration conf,
-                                                               FileSystem remoteFileSystem, String remotePath, int clusterType,
-                                                               boolean strictMode, FileSystem.Statistics statistics, long startBlock, long endBlock)
+  public static NonLocalReadRequestChain createNonLocalReadRequestChain(String remoteLocation,
+                                                                        long fileSize,
+                                                                        long lastModified,
+                                                                        Configuration conf,
+                                                                        FileSystem remoteFileSystem,
+                                                                        String remotePath,
+                                                                        int clusterType,
+                                                                        boolean strictMode,
+                                                                        FileSystem.Statistics statistics)
   {
-    if (readRequestChainType == NonLocalReadRequestChain.class) {
-      return readRequestChainType.cast(new NonLocalReadRequestChain(remoteLocation, fileSize, lastModified, conf, remoteFileSystem, remotePath, clusterType, strictMode, statistics));
-    }
-    else if (readRequestChainType == NonLocalRequestChain.class) {
-      return readRequestChainType.cast(new NonLocalRequestChain(remoteLocation, fileSize, lastModified, conf, remoteFileSystem, remotePath, clusterType, strictMode, statistics, startBlock, endBlock));
-    }
-    else if (readRequestChainType == RemoteFetchRequestChain.class) {
-      return readRequestChainType.cast(new RemoteFetchRequestChain(remotePath, remoteFileSystem, remoteLocation, conf, lastModified, fileSize, clusterType));
-    }
-    throw new IllegalArgumentException("The type of ReadRequestChain: " + readRequestChainType.getName() + " does not match the arguments or is unknown");
+    return new NonLocalReadRequestChain(remoteLocation, fileSize, lastModified, conf, remoteFileSystem, remotePath, clusterType, strictMode, statistics);
   }
 
-  public static <T extends ReadRequestChain> T createReadRequestChain(Class<T> readRequestChainType, FSDataInputStream inputStream, String localfile, ByteBuffer directBuffer, byte[] affixBuffer, BookKeeperFactory bookKeeperFactory) throws IOException
+  public static RemoteReadRequestChain createRemoteReadRequestChain(FSDataInputStream inputStream,
+                                                                    String localFile,
+                                                                    ByteBuffer directBuffer,
+                                                                    byte[] affixBuffer)
+          throws IOException
   {
-    if (readRequestChainType == RemoteReadRequestChain.class) {
-      if (bookKeeperFactory == null) {
-        bookKeeperFactory = new BookKeeperFactory();
-      }
-      return readRequestChainType.cast(new RemoteReadRequestChain(inputStream, localfile, directBuffer, affixBuffer, bookKeeperFactory));
-    }
-    throw new IllegalArgumentException("The type of ReadRequestChain: " + readRequestChainType.getName() + " does not match the arguments or is unknown");
+    return createRemoteReadRequestChain(inputStream, localFile, directBuffer, affixBuffer, new BookKeeperFactory());
   }
 
-  public static <T extends ReadRequestChain> T createReadRequestChain(Class<T> readRequestChainType, BookKeeperService.Client bookKeeperClient, FileSystem remoteFileSystem, String localfile,
-                                                               ByteBuffer directBuffer, Configuration conf, String remotePath,
-                                                               long fileSize, long lastModified)
+  public static RemoteReadRequestChain createRemoteReadRequestChain(FSDataInputStream inputStream,
+                                                                    String localFile,
+                                                                    ByteBuffer directBuffer,
+                                                                    byte[] affixBuffer,
+                                                                    BookKeeperFactory bookKeeperFactory)
+          throws IOException
   {
-    if (readRequestChainType == FileDownloadRequestChain.class) {
-      return readRequestChainType.cast(new FileDownloadRequestChain(bookKeeperClient, remoteFileSystem, localfile, directBuffer, conf, remotePath, fileSize, lastModified));
-    }
-    throw new IllegalArgumentException("The type of ReadRequestChain: " + readRequestChainType.getName() + " does not match the arguments or is unknown");
+    return new RemoteReadRequestChain(inputStream, localFile, directBuffer, affixBuffer, bookKeeperFactory);
+  }
+
+  public static NonLocalRequestChain createNonLocalRequestChain(String remoteLocation,
+                                                                long fileSize,
+                                                                long lastModified,
+                                                                Configuration conf,
+                                                                FileSystem remoteFileSystem,
+                                                                String remotePath,
+                                                                int clusterType,
+                                                                boolean strictMode,
+                                                                FileSystem.Statistics statistics,
+                                                                long startBlock,
+                                                                long endBlock)
+  {
+    return new NonLocalRequestChain(remoteLocation, fileSize, lastModified, conf, remoteFileSystem, remotePath, clusterType, strictMode, statistics, startBlock, endBlock);
+  }
+
+  public static RemoteFetchRequestChain createRemoteFetchRequestChain(String remoteLocation,
+                                                                      long fileSize,
+                                                                      long lastModified,
+                                                                      Configuration conf,
+                                                                      FileSystem remoteFileSystem,
+                                                                      String remotePath,
+                                                                      int clusterType)
+  {
+    return new RemoteFetchRequestChain(remotePath, remoteFileSystem, remoteLocation, conf, lastModified, fileSize, clusterType);
+  }
+
+  public static FileDownloadRequestChain createFileDownloadRequestChain(BookKeeperService.Client bookKeeperClient,
+                                                                        FileSystem remoteFileSystem,
+                                                                        String localFile,
+                                                                        ByteBuffer directBuffer,
+                                                                        Configuration conf,
+                                                                        String remotePath,
+                                                                        long fileSize,
+                                                                        long lastModified)
+  {
+    return new FileDownloadRequestChain(bookKeeperClient, remoteFileSystem, localFile, directBuffer, conf, remotePath, fileSize, lastModified);
   }
 }

--- a/rubix-core/src/main/java/com/qubole/rubix/core/RemoteReadRequestChain.java
+++ b/rubix-core/src/main/java/com/qubole/rubix/core/RemoteReadRequestChain.java
@@ -53,16 +53,6 @@ public class RemoteReadRequestChain extends ReadRequestChain
 
   private String localFile;
 
-  public RemoteReadRequestChain(FSDataInputStream inputStream, String localfile, ByteBuffer directBuffer, byte[] affixBuffer)
-      throws IOException
-  {
-    this(inputStream,
-        localfile,
-        directBuffer,
-        affixBuffer,
-        new BookKeeperFactory());
-  }
-
   public RemoteReadRequestChain(FSDataInputStream inputStream, String localfile, ByteBuffer directBuffer, byte[] affixBuffer, BookKeeperFactory bookKeeperFactory)
       throws IOException
   {
@@ -78,7 +68,7 @@ public class RemoteReadRequestChain extends ReadRequestChain
   public RemoteReadRequestChain(FSDataInputStream inputStream, String fileName)
       throws IOException
   {
-    this(inputStream, fileName, ByteBuffer.allocate(100), new byte[100]);
+    this(inputStream, fileName, ByteBuffer.allocate(100), new byte[100], new BookKeeperFactory());
   }
 
   public Integer call()

--- a/rubix-core/src/test/java/com/qubole/rubix/core/TestReadRequestChainFactory.java
+++ b/rubix-core/src/test/java/com/qubole/rubix/core/TestReadRequestChainFactory.java
@@ -24,21 +24,27 @@ public class TestReadRequestChainFactory
   @Test
   public void testReadRequestChainFactory() throws IOException
   {
-    assertEquals(ReadRequestChainFactory.createReadRequestChain(DirectReadRequestChain.class, null).getClass(), DirectReadRequestChain.class);
+    assertEquals(ReadRequestChainFactory.createDirectReadRequestChain(null).getClass(), DirectReadRequestChain.class);
 
-    assertEquals(ReadRequestChainFactory.createReadRequestChain(CachedReadRequestChain.class, null, null, null, null,
+    assertEquals(ReadRequestChainFactory.createCachedReadRequestChain(null, null, null, null,
              null, null).getClass(), CachedReadRequestChain.class);
 
-    assertEquals(ReadRequestChainFactory.createReadRequestChain(NonLocalReadRequestChain.class, null, 0, 0,
-             null, null, null, 0, false, null, 0, 0).getClass(), NonLocalReadRequestChain.class);
+    assertEquals(ReadRequestChainFactory.createNonLocalReadRequestChain(null, 0, 0,
+             null, null, null, 0, false, null).getClass(), NonLocalReadRequestChain.class);
 
-    assertEquals(ReadRequestChainFactory.createReadRequestChain(RemoteFetchRequestChain.class, null, 0, 0,
-            null, null, null, 0, false, null, 0, 0).getClass(), RemoteFetchRequestChain.class);
+    assertEquals(ReadRequestChainFactory.createRemoteFetchRequestChain(null, 0, 0,
+            null, null, null, 0).getClass(), RemoteFetchRequestChain.class);
 
-    assertEquals(ReadRequestChainFactory.createReadRequestChain(RemoteReadRequestChain.class, null, null, null,
+    assertEquals(ReadRequestChainFactory.createRemoteReadRequestChain(null, null, null,
             new byte[0], null).getClass(), RemoteReadRequestChain.class);
 
-    assertEquals(ReadRequestChainFactory.createReadRequestChain(FileDownloadRequestChain.class, null, null, null,
+    assertEquals(ReadRequestChainFactory.createRemoteReadRequestChain(null, null, null,
+            new byte[0]).getClass(), RemoteReadRequestChain.class);
+
+    assertEquals(ReadRequestChainFactory.createFileDownloadRequestChain(null, null, null,
             null, new Configuration(), null, 0, 0).getClass(), FileDownloadRequestChain.class);
+
+    assertEquals(ReadRequestChainFactory.createNonLocalRequestChain(null, 0, 0,
+            new Configuration(), null, null, 0, false, null, 0, 0).getClass(), NonLocalRequestChain.class);
   }
 }

--- a/rubix-core/src/test/java/com/qubole/rubix/core/TestReadRequestChainFactory.java
+++ b/rubix-core/src/test/java/com/qubole/rubix/core/TestReadRequestChainFactory.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2019. Qubole Inc
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License. See accompanying LICENSE file.
+ */
+package com.qubole.rubix.core;
+
+import org.apache.hadoop.conf.Configuration;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+
+import static org.testng.Assert.assertEquals;
+
+public class TestReadRequestChainFactory
+{
+  @Test
+  public void testReadRequestChainFactory() throws IOException
+  {
+    assertEquals(ReadRequestChainFactory.createReadRequestChain(DirectReadRequestChain.class, null).getClass(), DirectReadRequestChain.class);
+
+    assertEquals(ReadRequestChainFactory.createReadRequestChain(CachedReadRequestChain.class, null, null, null, null,
+             null, null).getClass(), CachedReadRequestChain.class);
+
+    assertEquals(ReadRequestChainFactory.createReadRequestChain(NonLocalReadRequestChain.class, null, 0, 0,
+             null, null, null, 0, false, null, 0, 0).getClass(), NonLocalReadRequestChain.class);
+
+    assertEquals(ReadRequestChainFactory.createReadRequestChain(RemoteFetchRequestChain.class, null, 0, 0,
+            null, null, null, 0, false, null, 0, 0).getClass(), RemoteFetchRequestChain.class);
+
+    assertEquals(ReadRequestChainFactory.createReadRequestChain(RemoteReadRequestChain.class, null, null, null,
+            new byte[0], null).getClass(), RemoteReadRequestChain.class);
+
+    assertEquals(ReadRequestChainFactory.createReadRequestChain(FileDownloadRequestChain.class, null, null, null,
+            null, new Configuration(), null, 0, 0).getClass(), FileDownloadRequestChain.class);
+  }
+}

--- a/rubix-tests/src/test/java/com/qubole/rubix/tests/TestNonLocalReadRequestChain.java
+++ b/rubix-tests/src/test/java/com/qubole/rubix/tests/TestNonLocalReadRequestChain.java
@@ -138,9 +138,9 @@ public class TestNonLocalReadRequestChain
   {
     MockCachingFileSystem fs = new MockCachingFileSystem();
     fs.initialize(backendPath.toUri(), conf);
-    NonLocalReadRequestChain requestChain = ReadRequestChainFactory.createReadRequestChain(NonLocalReadRequestChain.class, "localhost", backendFile.length(),
+    NonLocalReadRequestChain requestChain = ReadRequestChainFactory.createNonLocalReadRequestChain("localhost", backendFile.length(),
         backendFile.lastModified(), conf, fs, backendPath.toString(),
-        ClusterType.TEST_CLUSTER_MANAGER.ordinal(), false, null, 0, 0);
+        ClusterType.TEST_CLUSTER_MANAGER.ordinal(), false, null);
 
     return requestChain;
   }

--- a/rubix-tests/src/test/java/com/qubole/rubix/tests/TestNonLocalReadRequestChain.java
+++ b/rubix-tests/src/test/java/com/qubole/rubix/tests/TestNonLocalReadRequestChain.java
@@ -25,6 +25,7 @@ import com.qubole.rubix.common.utils.DeleteFileVisitor;
 import com.qubole.rubix.core.MockCachingFileSystem;
 import com.qubole.rubix.core.NonLocalReadRequestChain;
 import com.qubole.rubix.core.ReadRequest;
+import com.qubole.rubix.core.ReadRequestChainFactory;
 import com.qubole.rubix.spi.BookKeeperFactory;
 import com.qubole.rubix.spi.CacheConfig;
 import com.qubole.rubix.spi.CacheUtil;
@@ -137,9 +138,9 @@ public class TestNonLocalReadRequestChain
   {
     MockCachingFileSystem fs = new MockCachingFileSystem();
     fs.initialize(backendPath.toUri(), conf);
-    NonLocalReadRequestChain requestChain = new NonLocalReadRequestChain("localhost", backendFile.length(),
+    NonLocalReadRequestChain requestChain = ReadRequestChainFactory.createReadRequestChain(NonLocalReadRequestChain.class, "localhost", backendFile.length(),
         backendFile.lastModified(), conf, fs, backendPath.toString(),
-        ClusterType.TEST_CLUSTER_MANAGER.ordinal(), false, null);
+        ClusterType.TEST_CLUSTER_MANAGER.ordinal(), false, null, 0, 0);
 
     return requestChain;
   }


### PR DESCRIPTION
- Use RRCFactory to instantiate all the RRCs from a single location. This will help in having cleaner code and easy extension.

- Move FileDownloadRequestChain to rubix-core module with all the other RRCs