### PR TITLE
fix: dev: #297: Fix No such file or directory exception in bks logs

### DIFF
--- a/rubix-spi/src/main/java/com/qubole/rubix/spi/CacheUtil.java
+++ b/rubix-spi/src/main/java/com/qubole/rubix/spi/CacheUtil.java
@@ -57,7 +57,7 @@ public class CacheUtil
         if (exists(cacheParentDir)) {
           parentDirectoryExists = true;
           final String cacheDirPath = cacheParentDir + "/" + CacheConfig.getCacheDataDirSuffix(conf);
-          createCacheDirectory(cacheDirPath);
+          createCacheDirectory(cacheDirPath, conf);
         }
       }
     }
@@ -204,11 +204,15 @@ public class CacheUtil
    *
    * @param cacheDirPath  The path for which to create the directory.
    */
-  private static void createCacheDirectory(String cacheDirPath)
+  private static void createCacheDirectory(String cacheDirPath, Configuration conf)
   {
     final File cacheDir = new File(cacheDirPath);
     cacheDir.mkdirs();
-    cacheDir.setWritable(true, false);
+    File parentFile = cacheDir;
+    do {
+      parentFile.setWritable(true, false);
+      parentFile = parentFile.getParentFile();
+    } while (parentFile.getAbsolutePath().contains(CacheConfig.getCacheDataDirSuffix(conf).split("/")[1]));
   }
 
   /**
@@ -246,7 +250,7 @@ public class CacheUtil
     }
 
     final String absLocation = getLocalDirFor(remotePath, conf) + relLocation;
-    createCacheDirectory(absLocation);
+    createCacheDirectory(absLocation, conf);
 
     return absLocation;
   }


### PR DESCRIPTION
The exception occurred because the bks service did not have write privileges over the cache table directories and consequently was not able to create metadata files in the case of Non local reads. 

- Making the cached table directories writable recursively from Cache util

fixes #297 