### PR TITLE
fix: usr: #300: Modify getStats() in NonLocalRequestChain to report correct Cache Stats

### DIFF
--- a/rubix-core/src/main/java/com/qubole/rubix/core/NonLocalRequestChain.java
+++ b/rubix-core/src/main/java/com/qubole/rubix/core/NonLocalRequestChain.java
@@ -105,7 +105,13 @@ public class NonLocalRequestChain extends ReadRequestChain
 
   public ReadRequestChainStats getStats()
   {
-    return new ReadRequestChainStats().setRemoteReads(requests);
+    if (nonLocalReadRequestChain != null) {
+      return new ReadRequestChainStats().setNonLocalReads(nonLocalReadRequestChain.requests);
+    }
+    else {
+      // TODO: ReadRequestChainStats could collect number of direct reads from here
+      return new ReadRequestChainStats();
+    }
   }
 
   public void addReadRequest(ReadRequest readRequest)


### PR DESCRIPTION
- NonLocalRequestChain.getStats() was reporting all requests as remote reads which is wrong. 

- Marking those requests that go to the NonLocalReadRequestChain as nonlocal reads with this change. 

- The rest of the requests that go to the RemoteFetchRequestChain result in data getting downloaded asynchronously in the non-local node, while the requesting node falls back to direct reads, and direct reads stats are not collected.

fixes #300 