### PR TITLE
chg: dev: #310: cache Maven repository to reduce generated log lines

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ services:
   - docker
 jdk:
   - openjdk7
+cache:
+  directories:
+    - $HOME/.m2
 sudo: enabled
 before_install:
   - docker pull quboleinc/hadoop_mvn_thrift

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ sudo: enabled
 before_install:
   - docker pull quboleinc/hadoop_mvn_thrift
 install: true
-script: docker run -it --rm -v "$PWD":/usr/src/rubix -v "$HOME/.m2":/root/.m2 $ci_env -w /usr/src/rubix quboleinc/hadoop_mvn_thrift /bin/bash script.sh
+script:
+  - docker run -it --rm -v "$PWD":/usr/src/rubix -v "$HOME/.m2":/root/.m2 $ci_env -w /usr/src/rubix quboleinc/hadoop_mvn_thrift /bin/bash script.sh
 env:
   - ci_env=`bash <(curl -s https://codecov.io/env)`


### PR DESCRIPTION
Caching the Maven repository will significantly reduce the amount of log lines generated during CI builds, which will avoid build errors from reaching the maximum log length.