### PR TITLE
Allow connection backlog for socket accept()

### DIFF
--- a/rubix-bookkeeper/src/main/java/com/qubole/rubix/bookkeeper/BookKeeperServer.java
+++ b/rubix-bookkeeper/src/main/java/com/qubole/rubix/bookkeeper/BookKeeperServer.java
@@ -36,6 +36,7 @@ import org.apache.thrift.shaded.transport.TServerTransport;
 import org.apache.thrift.shaded.transport.TTransportException;
 
 import java.io.IOException;
+import java.net.InetSocketAddress;
 import java.util.concurrent.TimeUnit;
 
 import static com.qubole.rubix.spi.CacheConfig.getServerMaxThreads;
@@ -119,7 +120,8 @@ public class BookKeeperServer extends Configured implements Tool
     processor = new BookKeeperService.Processor(bookKeeper);
     log.info("Starting BookKeeperServer on port " + getServerPort(conf));
     try {
-      TServerTransport serverTransport = new TServerSocket(getServerPort(conf));
+      TServerTransport serverTransport = new TServerSocket(
+              new TServerSocket.ServerSocketTransportArgs().bindAddr(new InetSocketAddress(getServerPort(conf))).backlog(Integer.MAX_VALUE));
       server = new TThreadPoolServer(new TThreadPoolServer
           .Args(serverTransport)
           .processor(processor)

--- a/rubix-bookkeeper/src/main/java/com/qubole/rubix/bookkeeper/LocalDataTransferServer.java
+++ b/rubix-bookkeeper/src/main/java/com/qubole/rubix/bookkeeper/LocalDataTransferServer.java
@@ -150,7 +150,7 @@ public class LocalDataTransferServer extends Configured implements Tool
       ExecutorService threadPool = Executors.newCachedThreadPool();
       try {
         listener = ServerSocketChannel.open();
-        listener.bind(new InetSocketAddress(port));
+        listener.bind(new InetSocketAddress(port), Integer.MAX_VALUE);
         log.info("Listening on port " + port);
         while (true) {
           SocketChannel clientSocket = listener.accept();


### PR DESCRIPTION
In a test program to make 1000 BKS calls via 100 threads, lot of calls failed with "Connection reset" and other Socket Exceptions. It happens because the way we are configuring thrift server, it does not queue up any connection while socket accept() is busy handing over work to a worker thread. This change enables queueing up such connections by setting the queue length to maximum by setting it to Integer.MAX_VALUE (the real limit is implementation specific and not documented anywhere, used Integer.MAX_VALUE to get the maximum queue length).
After this change I could not repro the socket exceptions in my test program even after increasing number of calls and number of threads.