### PR TITLE
Fixes to prevent deadlocks with lower connection pool size

### DIFF
--- a/rubix-core/src/main/java/com/qubole/rubix/core/DummyModeCachingInputStream.java
+++ b/rubix-core/src/main/java/com/qubole/rubix/core/DummyModeCachingInputStream.java
@@ -14,13 +14,11 @@ package com.qubole.rubix.core;
 
 import com.google.common.base.Throwables;
 import com.qubole.rubix.spi.BookKeeperFactory;
-import com.qubole.rubix.spi.RetryingPooledBookkeeperClient;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-import org.apache.thrift.shaded.transport.TTransportException;
 
 import java.io.IOException;
 import java.util.List;
@@ -72,17 +70,13 @@ public class DummyModeCachingInputStream extends CachingInputStream
       @Override
       public void run()
       {
-        try (RetryingPooledBookkeeperClient client = bookKeeperFactory.createBookKeeperClient(conf)) {
+        try {
           long endBlock = ((initPos + (length - 1)) / blockSize) + 1;
           final List<ReadRequestChain> readRequestChains = setupReadRequestChains(buffer, offset, endBlock, length,
-              initPos, initNextReadBlock, client);
+              initPos, initNextReadBlock);
           updateCacheAndStats(readRequestChains);
         }
         catch (IOException e) {
-          throw Throwables.propagate(e);
-        }
-        catch (TTransportException e) {
-          log.warn("Could not create bookkeeper client", e);
           throw Throwables.propagate(e);
         }
       }

--- a/rubix-spi/src/main/java/com/qubole/rubix/spi/BookKeeperFactory.java
+++ b/rubix-spi/src/main/java/com/qubole/rubix/spi/BookKeeperFactory.java
@@ -61,7 +61,7 @@ public class BookKeeperFactory
     if (!initFlag.get()) {
       synchronized (initFlag) {
         if (!initFlag.get()) {
-          pool = createSocketObjectPool(conf, LOCALHOST, CacheConfig.getBookKeeperServerPort(conf));
+          pool = createSocketObjectPool(conf, host, CacheConfig.getBookKeeperServerPort(conf));
           initFlag.set(true);
         }
       }

--- a/rubix-spi/src/main/java/com/qubole/rubix/spi/CacheConfig.java
+++ b/rubix-spi/src/main/java/com/qubole/rubix/spi/CacheConfig.java
@@ -111,7 +111,7 @@ public class CacheConfig
   private static final int DEFAULT_BLOCK_SIZE = 1 * 1024 * 1024; // 1MB
   private static final int DEFAULT_SERVER_CONNECT_TIMEOUT = 1000; // ms
   private static final int DEFAULT_SERVER_SOCKET_TIMEOUT = 6000; // ms
-  private static final int DEFAULT_KEY_POOL_MAX_SIZE = 2000;
+  private static final int DEFAULT_KEY_POOL_MAX_SIZE = 200;
   private static final int DEFAULT_KEY_POOL_MIN_SIZE = 50;
   private static final int DEFAULT_KEY_POOL_DELTA_SIZE = 100;
   private static final int DEFAULT_POOL_MAX_WAIT_TIMEOUT = 5000; // ms

--- a/rubix-spi/src/main/java/com/qubole/rubix/spi/fop/ObjectPool.java
+++ b/rubix-spi/src/main/java/com/qubole/rubix/spi/fop/ObjectPool.java
@@ -68,7 +68,7 @@ public class ObjectPool<T>
     }
     log.debug("Borrowing object for partition: " + host);
     for (int i = 0; i < 3; i++) { // try at most three times
-      Poolable<T> result = getObject(true, host);
+      Poolable<T> result = getObject(false, host);
       if (factory.validate(result.getObject())) {
         return result;
       }
@@ -118,6 +118,8 @@ public class ObjectPool<T>
     if (!factory.validate(obj.getObject())) {
       log.debug(String.format("Invalid object for host %s removing %s ", obj.getHost(), obj));
       subPool.decreaseObject(obj);
+      // Compensate for the removed object. Needed to prevent endless wait when in parallel a borrowObject is called
+      subPool.increaseObjects(1);
       return;
     }
 

--- a/rubix-spi/src/main/java/com/qubole/rubix/spi/fop/ObjectPoolPartition.java
+++ b/rubix-spi/src/main/java/com/qubole/rubix/spi/fop/ObjectPoolPartition.java
@@ -65,6 +65,7 @@ public class ObjectPoolPartition<T>
 
   public synchronized int increaseObjects(int delta)
   {
+    int oldCount = totalCount;
     if (delta + totalCount > config.getMaxSize()) {
       delta = config.getMaxSize() - totalCount;
     }
@@ -76,7 +77,7 @@ public class ObjectPoolPartition<T>
           totalCount++;
         }
       }
-      log.debug("Increased pool size to: " + totalCount + ", current queue size: " + objectQueue.size());
+      log.debug("Increased pool size by " + (totalCount - oldCount) + " to new size: " + totalCount + ", current queue size: " + objectQueue.size());
     }
     catch (InterruptedException e) {
       throw new RuntimeException(e);


### PR DESCRIPTION
- Do not cache Client in CachingInputStream. It is light-weight to open new client now while caching client can lead to deadlock if consumer is moved out of scheduler
- Replace a connection which is being removed due a exception