### PR TITLE
Fix parallel warmup

### DIFF
--- a/rubix-bookkeeper/src/main/java/com/qubole/rubix/bookkeeper/BookKeeper.java
+++ b/rubix-bookkeeper/src/main/java/com/qubole/rubix/bookkeeper/BookKeeper.java
@@ -554,7 +554,7 @@ public abstract class BookKeeper implements BookKeeperService.Iface
           RemoteReadRequestChain remoteReadRequestChain = new RemoteReadRequestChain(inputStream, localPath, byteBuffer, buffer, new BookKeeperFactory(this));
           remoteReadRequestChain.addReadRequest(new ReadRequest(readStart, readStart + blockSize, readStart, readStart + blockSize, buffer, 0, fileSize));
           remoteReadRequestChain.lock();
-          Integer dataRead = remoteReadRequestChain.call();
+          long dataRead = remoteReadRequestChain.call();
           // Making sure the data downloaded matches with the expected bytes. If not, there is some problem with
           // the download this time. So won't update the cache metadata and return false so that client can
           // fall back on the directread

--- a/rubix-bookkeeper/src/main/java/com/qubole/rubix/bookkeeper/DownloadRequestContext.java
+++ b/rubix-bookkeeper/src/main/java/com/qubole/rubix/bookkeeper/DownloadRequestContext.java
@@ -52,7 +52,7 @@ public class DownloadRequestContext
 
   public void addDownloadRange(long startPoint, long endPoint)
   {
-    rangeSet.add(Range.open(startPoint, endPoint));
+    rangeSet.add(Range.closedOpen(startPoint, endPoint));
   }
 
   public RangeSet<Long> getRanges()

--- a/rubix-bookkeeper/src/main/java/com/qubole/rubix/bookkeeper/FetchRequest.java
+++ b/rubix-bookkeeper/src/main/java/com/qubole/rubix/bookkeeper/FetchRequest.java
@@ -13,6 +13,8 @@
 
 package com.qubole.rubix.bookkeeper;
 
+import java.util.Objects;
+
 public class FetchRequest
 {
   private String remotePath;
@@ -60,5 +62,29 @@ public class FetchRequest
   public long getRequestedTime()
   {
     return this.requestedTime;
+  }
+
+  @Override
+  public boolean equals(Object o)
+  {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    FetchRequest that = (FetchRequest) o;
+    return offset == that.offset &&
+            length == that.length &&
+            fileSize == that.fileSize &&
+            lastModified == that.lastModified &&
+            remotePath.equals(that.remotePath);
+  }
+
+  @Override
+  public int hashCode()
+  {
+    return Objects.hash(remotePath, offset, length, fileSize, lastModified);
   }
 }

--- a/rubix-bookkeeper/src/main/java/com/qubole/rubix/bookkeeper/FileDownloadRequestChain.java
+++ b/rubix-bookkeeper/src/main/java/com/qubole/rubix/bookkeeper/FileDownloadRequestChain.java
@@ -43,7 +43,7 @@ public class FileDownloadRequestChain extends ReadRequestChain
   private String remotePath;
   private long fileSize;
   private long lastModified;
-  private int totalRequestedRead;
+  private long totalRequestedRead;
   private int warmupPenalty;
   private int blockSize;
   Configuration conf;
@@ -87,7 +87,7 @@ public class FileDownloadRequestChain extends ReadRequestChain
     return this.timeSpentOnDownload;
   }
 
-  public Integer call() throws IOException
+  public Long call() throws IOException
   {
     log.debug(String.format("Read Request threadName: %s, FileDownload Executor threadName: %s", threadName, Thread.currentThread().getName()));
     Thread.currentThread().setName(threadName);
@@ -96,7 +96,7 @@ public class FileDownloadRequestChain extends ReadRequestChain
     List<ReadRequest> readRequests = getReadRequests();
 
     if (readRequests.size() == 0) {
-      return 0;
+      return 0L;
     }
 
     long startTime = System.currentTimeMillis();
@@ -126,7 +126,7 @@ public class FileDownloadRequestChain extends ReadRequestChain
           propagateCancel(this.getClass().getName());
         }
 
-        int readBytes = copyIntoCache(inputStream, fileChannel, readRequest.getBackendReadLength(), readRequest.getBackendReadStart());
+        int readBytes = copyIntoCache(inputStream, fileChannel, readRequest.getBackendReadLengthIntUnsafe(), readRequest.getBackendReadStart());
         totalRequestedRead += readBytes;
       }
       long endTime = System.currentTimeMillis();

--- a/rubix-bookkeeper/src/main/java/com/qubole/rubix/bookkeeper/FileDownloader.java
+++ b/rubix-bookkeeper/src/main/java/com/qubole/rubix/bookkeeper/FileDownloader.java
@@ -120,19 +120,19 @@ class FileDownloader
     }
 
     long sizeRead = 0;
-    List<Future<Integer>> futures = new ArrayList<Future<Integer>>();
+    List<Future<Long>> futures = new ArrayList<>();
 
     for (FileDownloadRequestChain requestChain : readRequestChainList) {
       requestChain.lock();
-      Future<Integer> result = processService.submit(requestChain);
+      Future<Long> result = processService.submit(requestChain);
       futures.add(result);
     }
 
-    for (Future<Integer> future : futures) {
+    for (Future<Long> future : futures) {
       FileDownloadRequestChain requestChain = readRequestChainList.get(futures.indexOf(future));
       long totalBytesToBeDownloaded = 0;
       for (ReadRequest request : requestChain.getReadRequests()) {
-        totalBytesToBeDownloaded += request.getBackendReadLength();
+        totalBytesToBeDownloaded += request.getBackendReadLengthIntUnsafe();
       }
       try {
         long read = future.get();

--- a/rubix-bookkeeper/src/main/java/com/qubole/rubix/bookkeeper/LocalDataTransferServer.java
+++ b/rubix-bookkeeper/src/main/java/com/qubole/rubix/bookkeeper/LocalDataTransferServer.java
@@ -292,7 +292,7 @@ public class LocalDataTransferServer extends Configured implements Tool
 
       try {
         fc = new FileInputStream(filename).getChannel();
-        int maxCount = CacheConfig.getLocalTransferBufferSize(conf);
+        int maxCount = CacheConfig.getDataTransferBufferSize(conf);
         int lengthRemaining = readLength;
         long position = offset;
 

--- a/rubix-bookkeeper/src/main/java/com/qubole/rubix/bookkeeper/LocalDataTransferServer.java
+++ b/rubix-bookkeeper/src/main/java/com/qubole/rubix/bookkeeper/LocalDataTransferServer.java
@@ -247,7 +247,7 @@ public class LocalDataTransferServer extends Configured implements Tool
             long endBlock = ((offset + (readLength - 1)) / blockSize) + 1;
 
             CacheStatusRequest request = new CacheStatusRequest(remotePath, header.getFileSize(), header.getLastModified(),
-                    startBlock, endBlock, header.getClusterType());
+                    startBlock, endBlock).setClusterType(header.getClusterType());
             List<BlockLocation> blockLocations = bookKeeperClient.getCacheStatus(request);
 
             long blockNum = startBlock;

--- a/rubix-bookkeeper/src/main/java/com/qubole/rubix/bookkeeper/validation/CachingValidator.java
+++ b/rubix-bookkeeper/src/main/java/com/qubole/rubix/bookkeeper/validation/CachingValidator.java
@@ -114,7 +114,7 @@ public class CachingValidator extends AbstractScheduledService
     final long fileLastModified = tempFile.lastModified();
 
     CacheStatusRequest request = new CacheStatusRequest(VALIDATOR_TEST_FILE_PATH_WITH_SCHEME, fileLength,
-        fileLastModified, VALIDATOR_START_BLOCK, VALIDATOR_END_BLOCK, VALIDATOR_CLUSTER_TYPE);
+        fileLastModified, VALIDATOR_START_BLOCK, VALIDATOR_END_BLOCK).setClusterType(VALIDATOR_CLUSTER_TYPE);
 
     try {
       List<BlockLocation> locations = bookKeeper.getCacheStatus(request);

--- a/rubix-bookkeeper/src/test/java/com/qubole/rubix/bookkeeper/TestBookKeeper.java
+++ b/rubix-bookkeeper/src/test/java/com/qubole/rubix/bookkeeper/TestBookKeeper.java
@@ -315,8 +315,9 @@ public class TestBookKeeper
     assertEquals(metrics.getCounters().get(BookKeeperMetrics.CacheMetric.TOTAL_REQUEST_COUNT.getMetricName()).getCount(), 0);
 
     CacheStatusRequest request = new CacheStatusRequest(TEST_REMOTE_PATH, TEST_FILE_LENGTH, TEST_LAST_MODIFIED,
-        TEST_START_BLOCK, TEST_END_BLOCK, ClusterType.TEST_CLUSTER_MANAGER.ordinal());
-    request.setIncrMetrics(true);
+        TEST_START_BLOCK, TEST_END_BLOCK)
+            .setClusterType(ClusterType.TEST_CLUSTER_MANAGER.ordinal())
+            .setIncrMetrics(true);
 
     bookKeeper.getCacheStatus(request);
 
@@ -331,7 +332,7 @@ public class TestBookKeeper
     assertEquals(metrics.getCounters().get(BookKeeperMetrics.CacheMetric.TOTAL_REQUEST_COUNT.getMetricName()).getCount(), 0);
 
     CacheStatusRequest request = new CacheStatusRequest(TEST_REMOTE_PATH, TEST_FILE_LENGTH, TEST_LAST_MODIFIED,
-        TEST_START_BLOCK, TEST_END_BLOCK, ClusterType.TEST_CLUSTER_MANAGER.ordinal());
+        TEST_START_BLOCK, TEST_END_BLOCK).setClusterType(ClusterType.TEST_CLUSTER_MANAGER.ordinal());
 
     bookKeeper.getCacheStatus(request);
 
@@ -351,8 +352,9 @@ public class TestBookKeeper
     assertEquals(metrics.getCounters().get(BookKeeperMetrics.CacheMetric.REMOTE_REQUEST_COUNT.getMetricName()).getCount(), 0);
 
     CacheStatusRequest request = new CacheStatusRequest(TEST_REMOTE_PATH, TEST_FILE_LENGTH, TEST_LAST_MODIFIED,
-        TEST_START_BLOCK, TEST_END_BLOCK, ClusterType.TEST_CLUSTER_MANAGER.ordinal());
-    request.setIncrMetrics(true);
+        TEST_START_BLOCK, TEST_END_BLOCK)
+            .setClusterType(ClusterType.TEST_CLUSTER_MANAGER.ordinal())
+            .setIncrMetrics(true);
 
     bookKeeper.getCacheStatus(request);
 
@@ -372,8 +374,9 @@ public class TestBookKeeper
     assertEquals(metrics.getCounters().get(BookKeeperMetrics.CacheMetric.CACHE_REQUEST_COUNT.getMetricName()).getCount(), 0);
 
     CacheStatusRequest request = new CacheStatusRequest(TEST_REMOTE_PATH, TEST_FILE_LENGTH, TEST_LAST_MODIFIED,
-        TEST_START_BLOCK, TEST_END_BLOCK, ClusterType.TEST_CLUSTER_MANAGER.ordinal());
-    request.setIncrMetrics(true);
+        TEST_START_BLOCK, TEST_END_BLOCK)
+            .setClusterType(ClusterType.TEST_CLUSTER_MANAGER.ordinal())
+            .setIncrMetrics(true);
 
     bookKeeper.getCacheStatus(request);
     bookKeeper.setAllCached(TEST_REMOTE_PATH, TEST_FILE_LENGTH, TEST_LAST_MODIFIED, TEST_START_BLOCK, TEST_END_BLOCK);
@@ -396,8 +399,9 @@ public class TestBookKeeper
     assertEquals(metrics.getCounters().get(BookKeeperMetrics.CacheMetric.CACHE_REQUEST_COUNT.getMetricName()).getCount(), 0);
 
     CacheStatusRequest request = new CacheStatusRequest(TEST_REMOTE_PATH, TEST_FILE_LENGTH, TEST_LAST_MODIFIED,
-        TEST_START_BLOCK, TEST_END_BLOCK, ClusterType.TEST_CLUSTER_MANAGER_MULTINODE.ordinal());
-    request.setIncrMetrics(true);
+        TEST_START_BLOCK, TEST_END_BLOCK)
+            .setClusterType(ClusterType.TEST_CLUSTER_MANAGER_MULTINODE.ordinal())
+            .setIncrMetrics(true);
 
     bookKeeper.getCacheStatus(request);
 
@@ -449,8 +453,9 @@ public class TestBookKeeper
       assertEquals(metrics.getCounters().get(BookKeeperMetrics.CacheMetric.CACHE_EXPIRY_COUNT.getMetricName()).getCount(), 0);
 
       CacheStatusRequest request = new CacheStatusRequest(TEST_REMOTE_PATH, TEST_FILE_LENGTH, TEST_LAST_MODIFIED,
-          TEST_START_BLOCK, TEST_END_BLOCK, ClusterType.TEST_CLUSTER_MANAGER.ordinal());
-      request.setIncrMetrics(true);
+          TEST_START_BLOCK, TEST_END_BLOCK)
+              .setClusterType(ClusterType.TEST_CLUSTER_MANAGER.ordinal())
+              .setIncrMetrics(true);
       bookKeeper.getCacheStatus(request);
 
       ticker.advance(30000, TimeUnit.MILLISECONDS);
@@ -472,8 +477,9 @@ public class TestBookKeeper
     assertEquals(metrics.getGauges().get(BookKeeperMetrics.CacheMetric.CACHE_MISS_RATE_GAUGE.getMetricName()).getValue(), Double.NaN);
 
     CacheStatusRequest request = new CacheStatusRequest(TEST_REMOTE_PATH, TEST_FILE_LENGTH, TEST_LAST_MODIFIED,
-        TEST_START_BLOCK, TEST_END_BLOCK, ClusterType.TEST_CLUSTER_MANAGER.ordinal());
-    request.setIncrMetrics(true);
+        TEST_START_BLOCK, TEST_END_BLOCK)
+            .setClusterType(ClusterType.TEST_CLUSTER_MANAGER.ordinal())
+            .setIncrMetrics(true);
     bookKeeper.getCacheStatus(request);
 
     assertEquals(metrics.getGauges().get(BookKeeperMetrics.CacheMetric.CACHE_HIT_RATE_GAUGE.getMetricName()).getValue(), 0.0);

--- a/rubix-bookkeeper/src/test/java/com/qubole/rubix/bookkeeper/TestFileDownloader.java
+++ b/rubix-bookkeeper/src/test/java/com/qubole/rubix/bookkeeper/TestFileDownloader.java
@@ -135,8 +135,8 @@ public class TestFileDownloader
     final Path backendPath = new Path("file:///" + TEST_BACKEND_FILE_NAME);
     final ConcurrentMap<String, DownloadRequestContext> contextMap = new ConcurrentHashMap<>();
 
-    CacheStatusRequest request = new CacheStatusRequest(backendPath.toString(), file.length(), 1000, 0, 5,
-        ClusterType.TEST_CLUSTER_MANAGER.ordinal());
+    CacheStatusRequest request = new CacheStatusRequest(backendPath.toString(), file.length(), 1000, 0, 5)
+            .setClusterType(ClusterType.TEST_CLUSTER_MANAGER.ordinal());
 
     List<BlockLocation> cacheStatus = bookKeeper.getCacheStatus(request);
 

--- a/rubix-bookkeeper/src/test/java/com/qubole/rubix/bookkeeper/TestFileDownloader.java
+++ b/rubix-bookkeeper/src/test/java/com/qubole/rubix/bookkeeper/TestFileDownloader.java
@@ -14,10 +14,12 @@
 package com.qubole.rubix.bookkeeper;
 
 import com.codahale.metrics.MetricRegistry;
+import com.google.common.collect.Range;
 import com.qubole.rubix.bookkeeper.utils.DiskUtils;
 import com.qubole.rubix.common.metrics.BookKeeperMetrics;
 import com.qubole.rubix.common.utils.DataGen;
 import com.qubole.rubix.common.utils.TestUtil;
+import com.qubole.rubix.core.ClusterManagerInitilizationException;
 import com.qubole.rubix.spi.CacheConfig;
 import com.qubole.rubix.spi.CacheUtil;
 import com.qubole.rubix.spi.ClusterType;
@@ -40,6 +42,7 @@ import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
+import static com.qubole.rubix.spi.ClusterType.TEST_CLUSTER_MANAGER;
 import static org.testng.Assert.assertTrue;
 
 /**
@@ -69,7 +72,8 @@ public class TestFileDownloader
   }
 
   @BeforeMethod
-  public void setUp() throws IOException
+  public void setUp()
+          throws IOException, ClusterManagerInitilizationException
   {
     CacheConfig.setCacheDataDirPrefix(conf, TEST_CACHE_DIR_PREFIX);
     CacheConfig.setBlockSize(conf, 200);
@@ -77,6 +81,8 @@ public class TestFileDownloader
     metrics = new MetricRegistry();
     bookKeeperMetrics = new BookKeeperMetrics(conf, metrics);
     bookKeeper = new CoordinatorBookKeeper(conf, bookKeeperMetrics);
+    // initialize bookKeeper
+    bookKeeper.initializeClusterManager(TEST_CLUSTER_MANAGER.ordinal());
     downloader = bookKeeper.getRemoteFetchProcessorInstance().getFileDownloaderInstance();
   }
 
@@ -119,8 +125,8 @@ public class TestFileDownloader
         "Wrong Number of Request Chains. Expected = 2 Got = " + requestChains.size());
 
     final FileDownloadRequestChain request1 = requestChains.get(0);
-    assertTrue(request1.getReadRequests().size() == 2,
-        "Wrong Number of Requests For File-1. Expected = 2 Got = " + request1.getReadRequests().size());
+    assertTrue(request1.getReadRequests().size() == 1,
+        "Wrong Number of Requests For File-1. Expected = 1 Got = " + request1.getReadRequests().size());
 
     final FileDownloadRequestChain request2 = requestChains.get(1);
     assertTrue(request2.getReadRequests().size() == 2,
@@ -136,7 +142,7 @@ public class TestFileDownloader
     final ConcurrentMap<String, DownloadRequestContext> contextMap = new ConcurrentHashMap<>();
 
     CacheStatusRequest request = new CacheStatusRequest(backendPath.toString(), file.length(), 1000, 0, 5)
-            .setClusterType(ClusterType.TEST_CLUSTER_MANAGER.ordinal());
+            .setClusterType(TEST_CLUSTER_MANAGER.ordinal());
 
     List<BlockLocation> cacheStatus = bookKeeper.getCacheStatus(request);
 
@@ -150,7 +156,7 @@ public class TestFileDownloader
 
     int dataDownloaded = (int) downloader.processDownloadRequests(requestChains);
 
-    int expectedDownloadedDataSize = 600;
+    int expectedDownloadedDataSize = 800;
     assertTrue(expectedDownloadedDataSize == dataDownloaded, "Download size didn't match");
 
     assertTrue(metrics.getCounters().get(BookKeeperMetrics.CacheMetric.ASYNC_DOWNLOADED_MB_COUNT.getMetricName())
@@ -163,5 +169,46 @@ public class TestFileDownloader
       assertTrue(cacheStatus.get(i).getLocation() == Location.CACHED, "Data is not cached");
     }
     assertTrue(cacheStatus.get(i).getLocation() == Location.LOCAL, "Data is cached");
+  }
+
+  @Test
+  public void testRequeuingFetchRequestOnFailure()
+          throws IOException
+  {
+    DataGen.populateFile(TEST_BACKEND_FILE_NAME);
+    final File file = new File(TEST_BACKEND_FILE_NAME);
+    final Path backendPath = new Path("file:///" + TEST_BACKEND_FILE_NAME);
+    final ConcurrentMap<String, DownloadRequestContext> contextMap = new ConcurrentHashMap<>();
+
+    bookKeeper = new CoordinatorBookKeeper(conf, new BookKeeperMetrics(conf, new MetricRegistry()));
+    // do not initialize bookkeeper to simulate error in communication with bookkeeper in FileDownloader
+
+    RemoteFetchProcessor remoteFetchProcessor = bookKeeper.getRemoteFetchProcessorInstance();
+    downloader = remoteFetchProcessor.getFileDownloaderInstance();
+
+    DownloadRequestContext context = new DownloadRequestContext(backendPath.toString(), file.length(), 1000);
+    contextMap.put(backendPath.toString(), context);
+    context.addDownloadRange(100, 300);
+    context.addDownloadRange(250, 400);
+    context.addDownloadRange(500, 800);
+
+    final List<FileDownloadRequestChain> requestChains = downloader.getFileDownloadRequestChains(contextMap);
+    assertTrue(requestChains.size() == 0, "Should not have created FileDownloadRequestChain as bookkeeper is not initialized");
+
+    // All ranges in context would have been re-queued
+    assertTrue(remoteFetchProcessor.getProcessQueue().size() == context.getRanges().asRanges().size(),
+            String.format("unexpected process queue size: %d, expected: %d", remoteFetchProcessor.getProcessQueue().size(), context.getRanges().asRanges().size()));
+
+    for (Range<Long> range: context.getRanges().asRanges()) {
+      FetchRequest actualFetchRequest = remoteFetchProcessor.getProcessQueue().poll();
+      FetchRequest expectedFetchRequest = new FetchRequest(
+              backendPath.toString(),
+              range.lowerEndpoint(),
+              Math.toIntExact(range.upperEndpoint() - range.lowerEndpoint()),
+              file.length(),
+              1000,
+              0 /* irrelevant */);
+      assertTrue(actualFetchRequest.equals(expectedFetchRequest), String.format("Actual: %s, Expected: %s", actualFetchRequest, expectedFetchRequest));
+    }
   }
 }

--- a/rubix-bookkeeper/src/test/java/com/qubole/rubix/bookkeeper/TestRemoteFetchProcessor.java
+++ b/rubix-bookkeeper/src/test/java/com/qubole/rubix/bookkeeper/TestRemoteFetchProcessor.java
@@ -17,6 +17,7 @@ import com.codahale.metrics.MetricRegistry;
 import com.qubole.rubix.common.metrics.BookKeeperMetrics;
 import com.qubole.rubix.common.utils.DataGen;
 import com.qubole.rubix.common.utils.TestUtil;
+import com.qubole.rubix.core.ClusterManagerInitilizationException;
 import com.qubole.rubix.spi.CacheConfig;
 import com.qubole.rubix.spi.CacheUtil;
 import org.apache.commons.logging.Log;
@@ -33,6 +34,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.concurrent.ConcurrentMap;
 
+import static com.qubole.rubix.spi.ClusterType.TEST_CLUSTER_MANAGER;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
@@ -65,7 +67,8 @@ public class TestRemoteFetchProcessor
   }
 
   @BeforeMethod
-  public void setUp() throws IOException
+  public void setUp()
+          throws IOException, ClusterManagerInitilizationException
   {
     CacheConfig.setCacheDataDirPrefix(conf, TEST_CACHE_DIR_PREFIX);
     CacheConfig.setRemoteFetchProcessInterval(conf, TEST_REMOTE_FETCH_PROCESS_INTERVAL);
@@ -73,6 +76,8 @@ public class TestRemoteFetchProcessor
     metrics = new MetricRegistry();
     bookKeeperMetrics = new BookKeeperMetrics(conf, metrics);
     bookKeeper = new CoordinatorBookKeeper(conf, bookKeeperMetrics);
+    // initialize bookKeeper
+    bookKeeper.initializeClusterManager(TEST_CLUSTER_MANAGER.ordinal());
     processor = bookKeeper.getRemoteFetchProcessorInstance();
   }
 

--- a/rubix-client/src/test/java/com/qubole/rubix/client/robotframework/BookKeeperClientRFLibrary.java
+++ b/rubix-client/src/test/java/com/qubole/rubix/client/robotframework/BookKeeperClientRFLibrary.java
@@ -155,8 +155,7 @@ public class BookKeeperClientRFLibrary
           request.getFileLength(),
           request.getLastModified(),
           request.getStartBlock(),
-          request.getEndBlock(),
-          request.getClusterType()));
+          request.getEndBlock()).setClusterType(request.getClusterType()));
     }
   }
 

--- a/rubix-common/src/main/java/com/qubole/rubix/common/utils/DataGen.java
+++ b/rubix-common/src/main/java/com/qubole/rubix/common/utils/DataGen.java
@@ -62,9 +62,9 @@ public class DataGen
     return expected.substring(0, size);
   }
 
-  public static String getExpectedOutput(int size)
+  public static String getExpectedOutput(long size)
   {
-    return getExpectedOutput(size, 100);
+    return getExpectedOutput(Math.toIntExact(size), 100);
   }
 
   public static void populateFile(String filename) throws IOException

--- a/rubix-core/src/main/java/com/qubole/rubix/core/CachingInputStream.java
+++ b/rubix-core/src/main/java/com/qubole/rubix/core/CachingInputStream.java
@@ -352,7 +352,7 @@ public class CachingInputStream extends FSInputStream
 
     try (RetryingPooledBookkeeperClient bookKeeperClient = bookKeeperFactory.createBookKeeperClient(conf)) {
       CacheStatusRequest request = new CacheStatusRequest(remotePath, fileSize, lastModified,
-          nextReadBlock, endBlock, clusterType.ordinal());
+          nextReadBlock, endBlock).setClusterType(clusterType.ordinal());
       request.setIncrMetrics(true);
       isCached = bookKeeperClient.getCacheStatus(request);
     }

--- a/rubix-core/src/main/java/com/qubole/rubix/core/ChainedReadRequestChain.java
+++ b/rubix-core/src/main/java/com/qubole/rubix/core/ChainedReadRequestChain.java
@@ -31,10 +31,10 @@ public class ChainedReadRequestChain extends ReadRequestChain
   }
 
   @Override
-  public Integer call()
+  public Long call()
       throws Exception
   {
-    int read = 0;
+    long read = 0;
     for (ReadRequestChain readRequestChain : readRequestChains) {
       readRequestChain.lock();
       read += readRequestChain.call();

--- a/rubix-core/src/main/java/com/qubole/rubix/core/DirectReadRequestChain.java
+++ b/rubix-core/src/main/java/com/qubole/rubix/core/DirectReadRequestChain.java
@@ -29,7 +29,7 @@ import static java.lang.String.format;
 public class DirectReadRequestChain extends ReadRequestChain
 {
   private final FSDataInputStream inputStream;
-  private int totalRead;
+  private long totalRead;
 
   private static final Log log = LogFactory.getLog(DirectReadRequestChain.class);
 
@@ -47,14 +47,14 @@ public class DirectReadRequestChain extends ReadRequestChain
   }
 
   @Override
-  public Integer call() throws IOException
+  public Long call() throws IOException
   {
     log.debug(String.format("Read Request threadName: %s, Direct read Executor threadName: %s", threadName, Thread.currentThread().getName()));
     Thread.currentThread().setName(threadName);
     long startTime = System.currentTimeMillis();
 
     if (readRequests.size() == 0) {
-      return 0;
+      return 0L;
     }
 
     checkState(isLocked, "Trying to execute Chain without locking");
@@ -64,13 +64,13 @@ public class DirectReadRequestChain extends ReadRequestChain
         propagateCancel(this.getClass().getName());
       }
       try {
-        inputStream.readFully(readRequest.actualReadStart, readRequest.getDestBuffer(), readRequest.getDestBufferOffset(), readRequest.getActualReadLength());
+        inputStream.readFully(readRequest.actualReadStart, readRequest.getDestBuffer(), readRequest.getDestBufferOffset(), readRequest.getActualReadLengthIntUnsafe());
       }
       catch (Exception e) {
-        log.error(format("Error reading %d bytes directly from remote at position %d", readRequest.getActualReadLength(), readRequest.actualReadStart), e);
+        log.error(format("Error reading %d bytes directly from remote at position %d", readRequest.getActualReadLengthIntUnsafe(), readRequest.actualReadStart), e);
         throw e;
       }
-      totalRead += readRequest.getActualReadLength();
+      totalRead += readRequest.getActualReadLengthIntUnsafe();
     }
     log.debug(String.format("Read %d bytes directly from remote, no caching", totalRead));
     log.debug("DirectReadRequest took : " + (System.currentTimeMillis() - startTime) + " msecs ");

--- a/rubix-core/src/main/java/com/qubole/rubix/core/NonLocalReadRequestChain.java
+++ b/rubix-core/src/main/java/com/qubole/rubix/core/NonLocalReadRequestChain.java
@@ -209,7 +209,7 @@ public class NonLocalReadRequestChain extends ReadRequestChain
           long startBlock = toBlock(readRequest.getBackendReadStart());
           long endBlock = toBlock(readRequest.getBackendReadEnd() - 1) + 1;
           // getCacheStatus() call required to create mdfiles before blocks are set as cached
-          CacheStatusRequest request = new CacheStatusRequest(remotePath, fileSize, lastModified, startBlock, endBlock, clusterType);
+          CacheStatusRequest request = new CacheStatusRequest(remotePath, fileSize, lastModified, startBlock, endBlock).setClusterType(clusterType);
           bookKeeperClient.getCacheStatus(request);
           bookKeeperClient.setAllCached(remotePath, fileSize, lastModified, startBlock, endBlock);
         }

--- a/rubix-core/src/main/java/com/qubole/rubix/core/NonLocalRequestChain.java
+++ b/rubix-core/src/main/java/com/qubole/rubix/core/NonLocalRequestChain.java
@@ -75,7 +75,7 @@ public class NonLocalRequestChain extends ReadRequestChain
               + " StartBlock : " + startBlock + " EndBlock : " + endBlock);
 
       CacheStatusRequest request = new CacheStatusRequest(remoteFilePath, fileSize, lastModified, startBlock,
-          endBlock, clusterType);
+          endBlock).setClusterType(clusterType);
       isCached = bookKeeperClient.getCacheStatus(request);
       log.debug("Cache Status : " + isCached);
     }

--- a/rubix-core/src/main/java/com/qubole/rubix/core/NonLocalRequestChain.java
+++ b/rubix-core/src/main/java/com/qubole/rubix/core/NonLocalRequestChain.java
@@ -131,15 +131,14 @@ public class NonLocalRequestChain extends ReadRequestChain
   }
 
   @Override
-  public Integer call() throws Exception
+  public Long call() throws Exception
   {
     log.debug(String.format("Read Request threadName: %s, NonLocal Executor threadName: %s", threadName, Thread.currentThread().getName()));
     Thread.currentThread().setName(threadName);
     checkState(isLocked, "Trying to execute Chain without locking");
     long startTime = System.currentTimeMillis();
 
-    int nonLocalReadBytes = 0;
-    int directReadBytes = 0;
+    long nonLocalReadBytes = 0;
 
     log.debug("Executing NonLocalRequestChain ");
 

--- a/rubix-core/src/main/java/com/qubole/rubix/core/ReadRequest.java
+++ b/rubix-core/src/main/java/com/qubole/rubix/core/ReadRequest.java
@@ -132,6 +132,17 @@ public class ReadRequest
     return Math.toIntExact(backendReadEnd - backendReadStart);
   }
 
+  public long getActualReadLength()
+  {
+    return actualReadEnd - actualReadStart;
+  }
+
+  public long getBackendReadLength()
+  {
+    return backendReadEnd - backendReadStart;
+  }
+
+
   public ReadRequest clone(boolean createNewBuffer)
   {
     ReadRequest otherRequest = new ReadRequest();

--- a/rubix-core/src/main/java/com/qubole/rubix/core/ReadRequest.java
+++ b/rubix-core/src/main/java/com/qubole/rubix/core/ReadRequest.java
@@ -120,14 +120,16 @@ public class ReadRequest
     this.backendFileSize = backendFileSize;
   }
 
-  public int getActualReadLength()
+  // Use this method only when caller is assured of no integer overflows
+  public int getActualReadLengthIntUnsafe()
   {
-    return (int) (actualReadEnd - actualReadStart);
+    return Math.toIntExact(actualReadEnd - actualReadStart);
   }
 
-  public int getBackendReadLength()
+  // Use this method only when caller is assured of no integer overflows
+  public int getBackendReadLengthIntUnsafe()
   {
-    return (int) (backendReadEnd - backendReadStart);
+    return Math.toIntExact(backendReadEnd - backendReadStart);
   }
 
   public ReadRequest clone(boolean createNewBuffer)

--- a/rubix-core/src/main/java/com/qubole/rubix/core/ReadRequestChain.java
+++ b/rubix-core/src/main/java/com/qubole/rubix/core/ReadRequestChain.java
@@ -27,8 +27,12 @@ import static com.google.common.base.Preconditions.checkState;
  * Created by stagra on 4/1/16.
  * <p>
  * One ReadRequestChain contains ReadRequests for same buffer
+ *
+ * ReadRequestChain works with `long` type, even though reads on input streams are limited by the capacity of `int`, in order
+ * to be generic and be useful in more cases than just reads on input streams. One such use case is of parallel warmup where
+ * reads are accumulated and merged for a period of time which can lead to reads of much bigger size than Integer.MAX_SIZE
  */
-public abstract class ReadRequestChain implements Callable<Integer>
+public abstract class ReadRequestChain implements Callable<Long>
 {
   List<ReadRequest> readRequests = new ArrayList<ReadRequest>();
   ReadRequest lastRequest;

--- a/rubix-core/src/main/java/com/qubole/rubix/core/ReadRequestChain.java
+++ b/rubix-core/src/main/java/com/qubole/rubix/core/ReadRequestChain.java
@@ -107,10 +107,19 @@ public abstract class ReadRequestChain implements Callable<Integer>
     throw new CancelledException(className + " Cancelled");
   }
 
-  private class CancelledException
+  protected class CancelledException
       extends IOException
   {
     public CancelledException(String message)
+    {
+      super(message);
+    }
+  }
+
+  protected class InvalidationRequiredException
+    extends IOException
+  {
+    public InvalidationRequiredException(String message)
     {
       super(message);
     }

--- a/rubix-core/src/main/java/com/qubole/rubix/core/RemoteFetchRequestChain.java
+++ b/rubix-core/src/main/java/com/qubole/rubix/core/RemoteFetchRequestChain.java
@@ -48,18 +48,18 @@ public class RemoteFetchRequestChain extends ReadRequestChain
   }
 
   @Override
-  public Integer call() throws Exception
+  public Long call() throws Exception
   {
     if (readRequests.size() == 0) {
-      return 0;
+      return 0L;
     }
     long startTime = System.currentTimeMillis();
 
     try (RetryingPooledBookkeeperClient client = bookKeeperFactory.createBookKeeperClient(remoteNodeLocation, conf)) {
       for (ReadRequest request : readRequests) {
         log.debug("RemoteFetchRequest from : " + remoteNodeLocation + " Start : " + request.backendReadStart +
-                " of length " + request.getBackendReadLength());
-        client.readData(remotePath, request.backendReadStart, request.getBackendReadLength(),
+                " of length " + request.getBackendReadLengthIntUnsafe());
+        client.readData(remotePath, request.backendReadStart, request.getBackendReadLengthIntUnsafe(),
             fileSize, lastModified, clusterType);
       }
     }
@@ -69,7 +69,7 @@ public class RemoteFetchRequestChain extends ReadRequestChain
     }
     log.debug("Send request to remote took " + (System.currentTimeMillis() - startTime) + " :msecs");
 
-    return 0;
+    return 0L;
   }
 
   public ReadRequestChainStats getStats()

--- a/rubix-core/src/main/java/com/qubole/rubix/core/RemoteFetchRequestChain.java
+++ b/rubix-core/src/main/java/com/qubole/rubix/core/RemoteFetchRequestChain.java
@@ -86,7 +86,7 @@ public class RemoteFetchRequestChain extends ReadRequestChain
           long startBlock = toBlock(readRequest.getBackendReadStart());
           long endBlock = toBlock(readRequest.getBackendReadEnd() - 1) + 1;
           // getCacheStatus() call required to create mdfiles before blocks are set as cached
-          CacheStatusRequest request = new CacheStatusRequest(remotePath, fileSize, lastModified, startBlock, endBlock, clusterType);
+          CacheStatusRequest request = new CacheStatusRequest(remotePath, fileSize, lastModified, startBlock, endBlock).setClusterType(clusterType);
           bookKeeperClient.getCacheStatus(request);
           bookKeeperClient.setAllCached(remotePath, fileSize, lastModified, startBlock, endBlock);
         }

--- a/rubix-core/src/main/java/com/qubole/rubix/core/RemoteReadRequestChain.java
+++ b/rubix-core/src/main/java/com/qubole/rubix/core/RemoteReadRequestChain.java
@@ -102,14 +102,14 @@ public class RemoteReadRequestChain extends ReadRequestChain
 
         if (prefixBufferLength > 0) {
           log.debug(String.format("Trying to Read %d bytes into prefix buffer", prefixBufferLength));
-          totalPrefixRead += readIntoBuffer(affixBuffer, 0, prefixBufferLength);
+          totalPrefixRead += readIntoBuffer(affixBuffer, 0, prefixBufferLength, inputStream);
           log.debug(String.format("Read %d bytes into prefix buffer", prefixBufferLength));
           copyIntoCache(fileChannel, affixBuffer, 0, prefixBufferLength, readRequest.backendReadStart);
           log.debug(String.format("Copied %d prefix bytes into cache", prefixBufferLength));
         }
 
         log.debug(String.format("Trying to Read %d bytes into destination buffer", readRequest.getActualReadLengthIntUnsafe()));
-        int readBytes = readIntoBuffer(readRequest.getDestBuffer(), readRequest.destBufferOffset, readRequest.getActualReadLengthIntUnsafe());
+        int readBytes = readIntoBuffer(readRequest.getDestBuffer(), readRequest.destBufferOffset, readRequest.getActualReadLengthIntUnsafe(), inputStream);
         log.debug(String.format("Read %d bytes into destination buffer", readBytes));
         copyIntoCache(fileChannel, readRequest.destBuffer, readRequest.destBufferOffset, readBytes, readRequest.actualReadStart);
         log.debug(String.format("Copied %d requested bytes into cache", readBytes));
@@ -119,7 +119,7 @@ public class RemoteReadRequestChain extends ReadRequestChain
           // If already in reading actually required data we get a eof, then there should not have been a suffix request
           checkState(readBytes == readRequest.getActualReadLengthIntUnsafe(), "Actual read less than required, still requested for suffix");
           log.debug(String.format("Trying to Read %d bytes into suffix buffer", suffixBufferLength));
-          totalSuffixRead += readIntoBuffer(affixBuffer, 0, suffixBufferLength);
+          totalSuffixRead += readIntoBuffer(affixBuffer, 0, suffixBufferLength, inputStream);
           log.debug(String.format("Read %d bytes into suffix buffer", suffixBufferLength));
           copyIntoCache(fileChannel, affixBuffer, 0, suffixBufferLength, readRequest.actualReadEnd);
           log.debug(String.format("Copied %d suffix bytes into cache", suffixBufferLength));
@@ -133,7 +133,7 @@ public class RemoteReadRequestChain extends ReadRequestChain
     }
   }
 
-  private int readIntoBuffer(byte[] destBuffer, int destBufferOffset, int length)
+  public static int readIntoBuffer(byte[] destBuffer, int destBufferOffset, int length, FSDataInputStream inputStream)
       throws IOException
   {
     int nread = 0;

--- a/rubix-core/src/test/java/com/qubole/rubix/core/TestCachedReadRequestChain.java
+++ b/rubix-core/src/test/java/com/qubole/rubix/core/TestCachedReadRequestChain.java
@@ -99,7 +99,7 @@ public class TestCachedReadRequestChain
     CachedReadRequestChain cachedReadRequestChain = getCachedReadRequestChain(buffer);
 
     cachedReadRequestChain.lock();
-    int readSize = cachedReadRequestChain.call();
+    long readSize = cachedReadRequestChain.call();
 
     ReadRequestChainStats stats = cachedReadRequestChain.getStats();
 
@@ -123,7 +123,7 @@ public class TestCachedReadRequestChain
     localFile.delete();
 
     cachedReadRequestChain.lock();
-    int readSize = cachedReadRequestChain.call();
+    long readSize = cachedReadRequestChain.call();
 
     ReadRequestChainStats stats = cachedReadRequestChain.getStats();
 
@@ -146,7 +146,7 @@ public class TestCachedReadRequestChain
     DataGen.truncateFile(localCachedFile, 1000);
 
     cachedReadRequestChain.lock();
-    int readSize = cachedReadRequestChain.call();
+    long readSize = cachedReadRequestChain.call();
 
     ReadRequestChainStats stats = cachedReadRequestChain.getStats();
 
@@ -169,7 +169,7 @@ public class TestCachedReadRequestChain
     DataGen.truncateFile(localCachedFile, 1800);
 
     cachedReadRequestChain.lock();
-    int readSize = cachedReadRequestChain.call();
+    long readSize = cachedReadRequestChain.call();
 
     ReadRequestChainStats stats = cachedReadRequestChain.getStats();
 

--- a/rubix-core/src/test/java/com/qubole/rubix/core/TestRemoteReadRequestChain.java
+++ b/rubix-core/src/test/java/com/qubole/rubix/core/TestRemoteReadRequestChain.java
@@ -121,7 +121,7 @@ public class TestRemoteReadRequestChain
     remoteReadRequestChain.lock();
 
     // 2. Execute and verify that buffer has right data
-    int readSize = remoteReadRequestChain.call();
+    long readSize = remoteReadRequestChain.call();
 
     assertTrue(readSize == expectedBufferOutput.length(), "Wrong amount of data read " + readSize + " was expecting " + expectedBufferOutput.length());
     String actualBufferOutput = new String(buffer, Charset.defaultCharset());

--- a/rubix-spi/src/main/java/com/qubole/rubix/spi/CacheConfig.java
+++ b/rubix-spi/src/main/java/com/qubole/rubix/spi/CacheConfig.java
@@ -59,7 +59,7 @@ public class CacheConfig
   private static final String KEY_DISK_READ_BUFFER_SIZE = "rubix.cache.data.disk.read.buffer.size";
   private static final String KEY_HEARTBEAT_INITIAL_DELAY = "rubix.monitor.heartbeat.initial.delay";
   private static final String KEY_HEARTBEAT_INTERVAL = "rubix.monitor.heartbeat.interval";
-  private static final String KEY_LOCAL_TRANSFER_BUFFER_SIZE = "rubix.cache.local.transfer.buffer.size";
+  private static final String KEY_DATA_TRANSFER_BUFFER_SIZE = "rubix.cache.data.transfer.buffer.size";
   private static final String KEY_LOCAL_SERVER_PORT = "rubix.network.local.transfer.server.port";
   private static final String KEY_MAX_RETRIES = "rubix.network.client.num-retries";
   private static final String KEY_METRICS_CACHE_ENABLED = "rubix.metrics.cache.enabled";
@@ -131,7 +131,7 @@ public class CacheConfig
   private static final int DEFAULT_DISK_READ_BUFFER_SIZE = 1024;
   private static final int DEFAULT_HEARTBEAT_INITIAL_DELAY = 30000; // ms
   private static final int DEFAULT_HEARTBEAT_INTERVAL = 30000; // ms
-  private static final int DEFAULT_LOCAL_TRANSFER_BUFFER_SIZE = 10 * 1024 * 1024; // 10MB
+  private static final int DEFAULT_DATA_TRANSFER_BUFFER_SIZE = 10 * 1024 * 1024; // 10MB
   private static final int DEFAULT_MAX_BUFFER_SIZE = 1024;
   private static final int DEFAULT_MAX_RETRIES = 3;
   private static final boolean DEFAULT_METRICS_CACHE_ENABLED = true;
@@ -310,9 +310,9 @@ public class CacheConfig
     return conf.getInt(KEY_LOCAL_SERVER_PORT, DEFAULT_DATA_TRANSFER_SERVER_PORT);
   }
 
-  public static int getLocalTransferBufferSize(Configuration conf)
+  public static int getDataTransferBufferSize (Configuration conf)
   {
-    return conf.getInt(KEY_LOCAL_TRANSFER_BUFFER_SIZE, DEFAULT_LOCAL_TRANSFER_BUFFER_SIZE);
+    return conf.getInt(KEY_DATA_TRANSFER_BUFFER_SIZE, DEFAULT_DATA_TRANSFER_BUFFER_SIZE);
   }
 
   public static int getMaxHeaderSize(Configuration conf)

--- a/rubix-spi/src/main/java/com/qubole/rubix/spi/CommonUtilities.java
+++ b/rubix-spi/src/main/java/com/qubole/rubix/spi/CommonUtilities.java
@@ -1,0 +1,73 @@
+/**
+ * Copyright (c) 2019. Qubole Inc
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License. See accompanying LICENSE file.
+ */
+package com.qubole.rubix.spi;
+
+import org.apache.hadoop.conf.Configuration;
+
+public class CommonUtilities
+{
+    private CommonUtilities()
+    {
+        // Static class
+    }
+
+    public static long toBlockStartPosition(long block, Configuration conf)
+    {
+        return block * CacheConfig.getBlockSize(conf);
+    }
+
+    public static long toBlockEndPosition(long block, Configuration conf)
+    {
+        return toBlockStartPosition(block + 1, conf) - 1;
+    }
+
+    public static long alignToBlockStartPosition(long position, Configuration conf)
+    {
+        return toStartBlock(position, conf) * CacheConfig.getBlockSize(conf);
+    }
+
+    public static long alignToBlockEndPosition(long position, Configuration conf)
+    {
+        return toEndBlock(position, conf) * CacheConfig.getBlockSize(conf);
+    }
+
+    public static long toStartBlock(long startingPosition, Configuration conf)
+    {
+        return toStartBlock(startingPosition, CacheConfig.getBlockSize(conf));
+    }
+
+    public static long toEndBlock(long endPosition, Configuration conf)
+    {
+        return toEndBlock(endPosition, CacheConfig.getBlockSize(conf));
+    }
+
+    /*
+     * For a request on range [startPosition, endPosition) this method returns the startBlockNumber if we convert
+     * the request range to block aligned request as [startBlockNumber, endBlockNumber) i.e. the first block (inclusive)
+     * from which the data read has to start
+     */
+    public static long toStartBlock(long startingPosition, int blockSize)
+    {
+        return startingPosition / blockSize;
+    }
+
+    /*
+     * For a request on range [startPosition, endPosition) this method returns the endBlockNumber if we convert
+     * the request range to block aligned request as [startBlockNumber, endBlockNumber) i.e. the block number at which
+     * the data read has to stop
+     */
+    public static long toEndBlock(long endPosition, int blockSize)
+    {
+        return ((endPosition - 1) / blockSize) + 1;
+    }
+}

--- a/rubix-spi/src/main/thrift/bookkeeper.thrift
+++ b/rubix-spi/src/main/thrift/bookkeeper.thrift
@@ -30,7 +30,7 @@ struct CacheStatusRequest {
 		3: required long lastModified;
 		4: required long startBlock;
 		5: required long endBlock;
-		6: required int clusterType;
+		6: optional int clusterType;
 		7: optional bool incrMetrics = false;
 }
 

--- a/rubix-tests/src/test/java/com/qubole/rubix/tests/TestNonLocalReadRequestChain.java
+++ b/rubix-tests/src/test/java/com/qubole/rubix/tests/TestNonLocalReadRequestChain.java
@@ -202,7 +202,7 @@ public class TestNonLocalReadRequestChain
     requestChain.lock();
 
     // 2. Execute and verify that buffer has right data
-    int readSize = requestChain.call();
+    long readSize = requestChain.call();
 
     assertTrue(readSize == 350, "Wrong amount of data read " + readSize + " was expecting " + 350);
     String output = new String(buffer, Charset.defaultCharset());

--- a/rubix-tests/src/test/java/com/qubole/rubix/tests/TestNonLocalReadRequestChain.java
+++ b/rubix-tests/src/test/java/com/qubole/rubix/tests/TestNonLocalReadRequestChain.java
@@ -338,7 +338,7 @@ public class TestNonLocalReadRequestChain
         backendFile.lastModified(), ClusterType.TEST_CLUSTER_MANAGER.ordinal());
 
     CacheStatusRequest request = new CacheStatusRequest(backendPath.toString(), backendFile.length(), backendFile.lastModified(),
-        0, endBlock, ClusterType.TEST_CLUSTER_MANAGER.ordinal());
+        0, endBlock).setClusterType(ClusterType.TEST_CLUSTER_MANAGER.ordinal());
     List<BlockLocation> blockLocations = client.getCacheStatus(request);
 
     for (BlockLocation location : blockLocations) {


### PR DESCRIPTION
Multiple fixes, reviewing by commits will be easier:
- Move ReadRequestChain.call to long type: so that we dont restrict Chains to 2GB download limits
- Make clusterType optional in CacheStatusRequest: this allows any client (like parallel warmup system), without the knowledge of cluster-type, to communicate with bookKeeper as long as bookKeeper has been initialized
- Download from remote in chunks of max 10MB (configurable) during parallel warmup: This fixes heavy memory usage.
- Align readRequests to block boundary: This fixes cases of wrong updates to cache leading to read errors
- Use BookKeeper to create metadata-file instead of doing the work from outside
- Fix Ranges in DownloadRequestContext to be closed-open instead of open-open: This improves merging of ranges
- Avoid redundant warm-ups of blocks that have already been cached: This speeds up parallel warmup and also avoid unnecessary setAllCached requests to BookKeeper for blocks in cache
- Fix wrong accounting of fileSize in cache when setAllCached is called with blocks already in cache. This, along with previous point, was leading to cache evictions due to SIZE even when cache was less than 20% used