### PR TITLE
Document the dependencies and build process

### DIFF
--- a/docs/contrib/env.md
+++ b/docs/contrib/env.md
@@ -4,6 +4,25 @@ Rubix is a Maven project and uses Java 8. It uses JUnit as the testing framework
 Ensure that you have a development environment that support the above 
 configuration.
 
+## Pre-requisites
+
+* `thrift` binary needs to be available at `/usr/local/bin/thrift`.
+  For Debian-based systems:
+  ```sh
+  sudo apt-get install thrift-compiler
+  sudo ln -s /usr/bin/thrift /usr/local/bin/thrift
+  ```
+  For RPM-based systems:
+  ```sh
+  sudo yum install epel-release
+  sudo yum install thrift
+  sudo ln -s /usr/bin/thrift /usr/local/bin/thrift
+  ```
+* Java JDK 8 needs to be used since JDK versions > 9 don't ship with `tools.jar`. So if you see an error like `Could not find artifact jdk.tools:jdk.tools:jar:1.6 at specified path` then setup your system to use JDK 8 for the build.
+* For generating the RPM you need the `rpmbuild` command available. On Debian-based systems `sudo apt-get install rpmbuild` and on RPM-based systems `sudo yum install rpm-build` make it available.
+
+## Building
+
 * Fork your own copy of RubiX into your github account by clicking on the "Fork" button
 * Navigate to your account and clone that copy to your development box
 

--- a/docs/contrib/env.md
+++ b/docs/contrib/env.md
@@ -6,7 +6,8 @@ configuration.
 
 ## Pre-requisites
 
-* `thrift` binary needs to be available at `/usr/local/bin/thrift`.
+* `thrift` binary needs to be available at `/usr/local/bin/thrift` and the version of thrift should match the version you are going to deploy on. We mostly use thrift 0.9.3. In case you get errors with the thrift version installed by following below steps, please install from source by following the steps [here](https://thrift.apache.org/docs/install/).
+
   For Debian-based systems:
   ```sh
   sudo apt-get install thrift-compiler

--- a/docs/contrib/env.md
+++ b/docs/contrib/env.md
@@ -18,7 +18,7 @@ configuration.
   sudo yum install thrift
   sudo ln -s /usr/bin/thrift /usr/local/bin/thrift
   ```
-* Java JDK 8 needs to be used since JDK versions > 9 don't ship with `tools.jar`. So if you see an error like `Could not find artifact jdk.tools:jdk.tools:jar:1.6 at specified path` then setup your system to use JDK 8 for the build.
+* Java JDK 8 needs to be used since JDK versions > 8 don't ship with `tools.jar`. So if you see an error like `Could not find artifact jdk.tools:jdk.tools:jar:1.6 at specified path` then setup your system to use Java JDK 8 for the build.
 * For generating the RPM you need the `rpmbuild` command available. On Debian-based systems `sudo apt-get install rpmbuild` and on RPM-based systems `sudo yum install rpm-build` make it available.
 
 ## Building


### PR DESCRIPTION
Add detailed steps so that people can more easily get set up with Rubix and contribute faster to Rubix.