### PR TITLE
add generation Number

### DIFF
--- a/rubix-bookkeeper/src/main/java/com/qubole/rubix/bookkeeper/validation/FileValidatorVisitor.java
+++ b/rubix-bookkeeper/src/main/java/com/qubole/rubix/bookkeeper/validation/FileValidatorVisitor.java
@@ -50,8 +50,9 @@ public class FileValidatorVisitor extends SimpleFileVisitor<Path>
   {
     if (!CacheUtil.isMetadataFile(file.toString(), conf)) {
       totalCacheFiles++;
-
-      Path mdFile = file.resolveSibling(file.getFileName() + metadataFileSuffix);
+      String fileName = file.toString();
+      int generationNumber = Integer.parseInt(fileName.substring(fileName.indexOf("_g") + 2));
+      Path mdFile = file.resolveSibling(file.getFileName() + metadataFileSuffix + generationNumber);
       if (Files.exists(mdFile)) {
         successes++;
       }

--- a/rubix-bookkeeper/src/test/java/com/qubole/rubix/bookkeeper/TestFileDownloader.java
+++ b/rubix-bookkeeper/src/test/java/com/qubole/rubix/bookkeeper/TestFileDownloader.java
@@ -145,7 +145,7 @@ public class TestFileDownloader
     CacheStatusRequest request = new CacheStatusRequest(backendPath.toString(), file.length(), 1000, 0, 5)
             .setClusterType(TEST_CLUSTER_MANAGER.ordinal());
 
-    List<BlockLocation> cacheStatus = bookKeeper.getCacheStatus(request);
+    List<BlockLocation> cacheStatus = bookKeeper.getCacheStatus(request).getBlocks();
 
     DownloadRequestContext context = new DownloadRequestContext(backendPath.toString(), file.length(), 1000);
     contextMap.put(backendPath.toString(), context);
@@ -163,7 +163,7 @@ public class TestFileDownloader
     assertTrue(metrics.getCounters().get(BookKeeperMetrics.CacheMetric.ASYNC_DOWNLOADED_MB_COUNT.getMetricName())
         .getCount() == BYTES.toMB(expectedDownloadedDataSize), "Total downloaded bytes didn't match");
 
-    cacheStatus = bookKeeper.getCacheStatus(request);
+    cacheStatus = bookKeeper.getCacheStatus(request).getBlocks();
 
     int i = 0;
     for (i = 0; i < 4; i++) {
@@ -251,7 +251,7 @@ public class TestFileDownloader
 
     CacheStatusRequest request = new CacheStatusRequest(backendPath.toString(), file.length(), 1000, 0, 6)
             .setClusterType(TEST_CLUSTER_MANAGER.ordinal());
-    List<BlockLocation> cacheStatus = bookKeeper.getCacheStatus(request);
+    List<BlockLocation> cacheStatus = bookKeeper.getCacheStatus(request).getBlocks();
 
     int i = 0;
     for (i = 0; i < 5; i++) {

--- a/rubix-bookkeeper/src/test/java/com/qubole/rubix/bookkeeper/TestRemoteFetchProcessor.java
+++ b/rubix-bookkeeper/src/test/java/com/qubole/rubix/bookkeeper/TestRemoteFetchProcessor.java
@@ -216,7 +216,7 @@ public class TestRemoteFetchProcessor
     assertEquals(metrics.getGauges().get(BookKeeperMetrics.CacheMetric.ASYNC_QUEUE_SIZE_GAUGE.getMetricName())
         .getValue(), 0, "All the requests should have been processed and the queue size should be zero");
 
-    final String downloadedFile = CacheUtil.getLocalPath(backendPath.toString(), conf);
+    final String downloadedFile = CacheUtil.getLocalPath(backendPath.toString(), conf, bookKeeper.getFileMetadata(backendPath.toString()).getGenerationNumber());
     final String resultString = new String(DataGen.readBytesFromFile(downloadedFile, 0, 450));
 
     final String expected = DataGen.generateContent().substring(0, 450);
@@ -253,7 +253,7 @@ public class TestRemoteFetchProcessor
     assertTrue(metrics.getCounters().get(BookKeeperMetrics.CacheMetric.PROCESSED_ASYNC_REQUEST_COUNT.getMetricName())
         .getCount() == (maxOffset / offsetStep), "Not all the requests are processed");
 
-    final String downloadedFile = CacheUtil.getLocalPath(backendPath.toString(), conf);
+    final String downloadedFile = CacheUtil.getLocalPath(backendPath.toString(), conf, bookKeeper.getFileMetadata(backendPath.toString()).getGenerationNumber());
 
     String resultString = null;
     String expected = null;

--- a/rubix-bookkeeper/src/test/java/com/qubole/rubix/bookkeeper/validation/ValidatorFileGen.java
+++ b/rubix-bookkeeper/src/test/java/com/qubole/rubix/bookkeeper/validation/ValidatorFileGen.java
@@ -113,12 +113,12 @@ public class ValidatorFileGen
     final String mdFileSuffix = CacheConfig.getCacheMetadataFileSuffix(conf);
 
     for (int fileNum = 0; fileNum < files; fileNum++) {
-      String fileName = RandomStringUtils.random(FILE_NAME_LENGTH, true, true);
+      String fileName = RandomStringUtils.random(FILE_NAME_LENGTH, true, true) + "_g" + fileNum;
       Path filePath = parentDirPath.resolve(fileName);
       Files.createFile(filePath);
 
       if ((fileNum % mdStep == 0)) {
-        Path mdFilePath = filePath.resolveSibling(filePath.getFileName() + mdFileSuffix);
+        Path mdFilePath = filePath.resolveSibling(filePath.getFileName() + mdFileSuffix + fileNum);
         Files.createFile(mdFilePath);
         mdFilesCreated++;
       }
@@ -128,7 +128,6 @@ public class ValidatorFileGen
 
       filesCreated++;
     }
-
     return new FileGenResult(filesCreated, mdFilesCreated, filesWithoutMD);
   }
 

--- a/rubix-client/src/test/java/com/qubole/rubix/client/robotframework/BookKeeperClientRFLibrary.java
+++ b/rubix-client/src/test/java/com/qubole/rubix/client/robotframework/BookKeeperClientRFLibrary.java
@@ -18,6 +18,7 @@ import com.qubole.rubix.spi.CacheUtil;
 import com.qubole.rubix.spi.RetryingPooledBookkeeperClient;
 import com.qubole.rubix.spi.thrift.BlockLocation;
 import com.qubole.rubix.spi.thrift.CacheStatusRequest;
+import com.qubole.rubix.spi.thrift.ReadResponse;
 import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataInputStream;
@@ -42,6 +43,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
 import static com.qubole.rubix.spi.utils.DataSizeUnits.BYTES;
+import static com.qubole.rubix.spi.CacheUtil.UNKONWN_GENERATION_NUMBER;
 
 public class BookKeeperClientRFLibrary
 {
@@ -64,7 +66,7 @@ public class BookKeeperClientRFLibrary
           readRequest.getReadLength(),
           readRequest.getFileLength(),
           readRequest.getLastModified(),
-          readRequest.getClusterType());
+          readRequest.getClusterType()).isStatus();
     }
   }
 
@@ -157,7 +159,8 @@ public class BookKeeperClientRFLibrary
           request.getFileLength(),
           request.getLastModified(),
           request.getStartBlock(),
-          request.getEndBlock()).setClusterType(request.getClusterType()));
+          request.getEndBlock()).setClusterType(request.getClusterType()))
+          .getBlocks();
     }
   }
 
@@ -213,7 +216,7 @@ public class BookKeeperClientRFLibrary
    */
   public String generateTestMDFile(String filename) throws IOException
   {
-    String mdPath = CacheUtil.getMetadataFilePath(filename, conf);
+    String mdPath = CacheUtil.getMetadataFilePath(filename, conf, UNKONWN_GENERATION_NUMBER + 1);
     // Certain tests require a non-empty metadata file.
     Files.write(Paths.get(mdPath), "0101010101".getBytes());
     return mdPath;

--- a/rubix-client/src/test/java/com/qubole/rubix/client/robotframework/CacheWatcher.java
+++ b/rubix-client/src/test/java/com/qubole/rubix/client/robotframework/CacheWatcher.java
@@ -35,6 +35,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
+import static com.qubole.rubix.spi.CacheUtil.UNKONWN_GENERATION_NUMBER;
 import static java.nio.file.StandardWatchEventKinds.ENTRY_CREATE;
 import static java.nio.file.StandardWatchEventKinds.ENTRY_DELETE;
 import static java.nio.file.StandardWatchEventKinds.ENTRY_MODIFY;
@@ -124,7 +125,7 @@ public class CacheWatcher
     Map<Path, Boolean> fileCacheStatus = new HashMap<>();
 
     for (TestClientReadRequest request : requests) {
-      Path cacheFile = Paths.get(CacheUtil.getLocalPath(request.getRemotePath(), conf));
+      Path cacheFile = Paths.get(CacheUtil.getLocalPath(request.getRemotePath(), conf, UNKONWN_GENERATION_NUMBER + 1));
       int expectedSize = request.getReadLength();
 
       if (Files.exists(cacheFile)) {

--- a/rubix-core/src/main/java/com/qubole/rubix/core/ChainedReadRequestChain.java
+++ b/rubix-core/src/main/java/com/qubole/rubix/core/ChainedReadRequestChain.java
@@ -17,12 +17,19 @@ import org.apache.hadoop.conf.Configuration;
 import java.util.ArrayList;
 import java.util.List;
 
+import static com.qubole.rubix.spi.CacheUtil.UNKONWN_GENERATION_NUMBER;
+
 /**
  * Created by qubole on 14/9/16.
  */
 public class ChainedReadRequestChain extends ReadRequestChain
 {
   private List<ReadRequestChain> readRequestChains = new ArrayList<>();
+
+  public ChainedReadRequestChain()
+  {
+    super(UNKONWN_GENERATION_NUMBER);
+  }
 
   public ChainedReadRequestChain addReadRequestChain(ReadRequestChain readRequestChain)
   {

--- a/rubix-core/src/main/java/com/qubole/rubix/core/DirectReadRequestChain.java
+++ b/rubix-core/src/main/java/com/qubole/rubix/core/DirectReadRequestChain.java
@@ -19,6 +19,7 @@ import org.apache.hadoop.fs.FSDataInputStream;
 import java.io.IOException;
 
 import static com.google.common.base.Preconditions.checkState;
+import static com.qubole.rubix.spi.CacheUtil.UNKONWN_GENERATION_NUMBER;
 import static java.lang.String.format;
 
 /**
@@ -35,6 +36,7 @@ public class DirectReadRequestChain extends ReadRequestChain
 
   public DirectReadRequestChain(FSDataInputStream inputStream)
   {
+    super(UNKONWN_GENERATION_NUMBER);
     this.inputStream = inputStream;
   }
 

--- a/rubix-core/src/main/java/com/qubole/rubix/core/DummyModeCachingInputStream.java
+++ b/rubix-core/src/main/java/com/qubole/rubix/core/DummyModeCachingInputStream.java
@@ -88,8 +88,12 @@ public class DummyModeCachingInputStream extends CachingInputStream
       {
         try {
           long endBlock = ((initPos + (length - 1)) / blockSize) + 1;
-          final List<ReadRequestChain> readRequestChains = setupReadRequestChains(buffer, offset, endBlock, length,
-                  initPos, initNextReadBlock);
+          final List<ReadRequestChain> readRequestChains = setupReadRequestChains(buffer,
+              offset,
+              endBlock,
+              length,
+              initPos,
+              initNextReadBlock);
           updateCacheAndStats(readRequestChains);
         }
         catch (IOException e) {

--- a/rubix-core/src/main/java/com/qubole/rubix/core/NonLocalRequestChain.java
+++ b/rubix-core/src/main/java/com/qubole/rubix/core/NonLocalRequestChain.java
@@ -27,6 +27,7 @@ import org.apache.hadoop.fs.FileSystem;
 import java.util.List;
 
 import static com.google.common.base.Preconditions.checkState;
+import static com.qubole.rubix.spi.CacheUtil.UNKONWN_GENERATION_NUMBER;
 
 public class NonLocalRequestChain extends ReadRequestChain
 {
@@ -55,6 +56,7 @@ public class NonLocalRequestChain extends ReadRequestChain
                               boolean strictMode, FileSystem.Statistics statistics, long startBlock,
                               long endBlock, BookKeeperFactory bookKeeperFactory)
   {
+    super(UNKONWN_GENERATION_NUMBER);
     this.remoteNodeName = remoteNodeName;
     this.remoteFileSystem = remoteFileSystem;
     this.lastModified = lastModified;
@@ -76,7 +78,7 @@ public class NonLocalRequestChain extends ReadRequestChain
 
       CacheStatusRequest request = new CacheStatusRequest(remoteFilePath, fileSize, lastModified, startBlock,
           endBlock).setClusterType(clusterType);
-      isCached = bookKeeperClient.getCacheStatus(request);
+      isCached = bookKeeperClient.getCacheStatus(request).getBlocks();
       log.debug("Cache Status : " + isCached);
     }
     catch (Exception e) {

--- a/rubix-core/src/main/java/com/qubole/rubix/core/ReadRequestChain.java
+++ b/rubix-core/src/main/java/com/qubole/rubix/core/ReadRequestChain.java
@@ -38,15 +38,17 @@ public abstract class ReadRequestChain implements Callable<Long>
   ReadRequest lastRequest;
   boolean isLocked;
   boolean cancelled;
+  protected final int generationNumber;
 
   protected String threadName;
   protected long requests;
 
   private static final Log log = LogFactory.getLog(ReadRequestChain.class);
 
-  public ReadRequestChain()
+  public ReadRequestChain(int generationNumber)
   {
     super();
+    this.generationNumber = generationNumber;
     this.threadName = Thread.currentThread().getName();
   }
 

--- a/rubix-core/src/main/java/com/qubole/rubix/core/RemoteFetchRequestChain.java
+++ b/rubix-core/src/main/java/com/qubole/rubix/core/RemoteFetchRequestChain.java
@@ -21,6 +21,9 @@ import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 
+import static com.qubole.rubix.spi.CacheUtil.DUMMY_MODE_GENERATION_NUMBER;
+import static com.qubole.rubix.spi.CacheUtil.UNKONWN_GENERATION_NUMBER;
+
 public class RemoteFetchRequestChain extends ReadRequestChain
 {
   private static final Log log = LogFactory.getLog(RemoteFetchRequestChain.class);
@@ -37,6 +40,7 @@ public class RemoteFetchRequestChain extends ReadRequestChain
   public RemoteFetchRequestChain(String remotePath, FileSystem remoteFileSystem, String remoteNodeLocation,
                                  Configuration conf, long lastModified, long fileSize, int clusterType, BookKeeperFactory bookKeeperFactory)
   {
+    super(UNKONWN_GENERATION_NUMBER);
     this.remotePath = remotePath;
     this.remoteFileSystem = remoteFileSystem;
     this.remoteNodeLocation = remoteNodeLocation;
@@ -88,7 +92,7 @@ public class RemoteFetchRequestChain extends ReadRequestChain
           // getCacheStatus() call required to create mdfiles before blocks are set as cached
           CacheStatusRequest request = new CacheStatusRequest(remotePath, fileSize, lastModified, startBlock, endBlock).setClusterType(clusterType);
           bookKeeperClient.getCacheStatus(request);
-          bookKeeperClient.setAllCached(remotePath, fileSize, lastModified, startBlock, endBlock);
+          bookKeeperClient.setAllCached(remotePath, fileSize, lastModified, startBlock, endBlock, DUMMY_MODE_GENERATION_NUMBER);
         }
       }
       catch (Exception e) {

--- a/rubix-core/src/main/java/com/qubole/rubix/core/RemoteReadRequestChain.java
+++ b/rubix-core/src/main/java/com/qubole/rubix/core/RemoteReadRequestChain.java
@@ -14,6 +14,8 @@ package com.qubole.rubix.core;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.qubole.rubix.spi.BookKeeperFactory;
+import com.qubole.rubix.spi.CacheConfig;
+import com.qubole.rubix.spi.CacheUtil;
 import com.qubole.rubix.spi.RetryingPooledBookkeeperClient;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -55,21 +57,28 @@ public class RemoteReadRequestChain extends ReadRequestChain
 
   private String localFile;
 
-  public RemoteReadRequestChain(FSDataInputStream inputStream, String localfile, DirectBufferPool bufferPool, int directBufferSize, byte[] affixBuffer, BookKeeperFactory bookKeeperFactory)
+  public RemoteReadRequestChain(FSDataInputStream inputStream,
+      String remotePath,
+      int generationNumber,
+      DirectBufferPool bufferPool,
+      Configuration conf,
+      byte[] affixBuffer,
+      BookKeeperFactory bookKeeperFactory)
   {
+    super(generationNumber);
     this.inputStream = inputStream;
     this.bufferPool = bufferPool;
-    this.directBufferSize = directBufferSize;
+    this.directBufferSize = CacheConfig.getDiskReadBufferSize(conf);
     this.affixBuffer = affixBuffer;
     this.blockSize = affixBuffer.length;
-    this.localFile = localfile;
+    this.localFile = CacheUtil.getLocalPath(remotePath, conf, generationNumber);
     this.bookKeeperFactory = bookKeeperFactory;
   }
 
   @VisibleForTesting
-  public RemoteReadRequestChain(FSDataInputStream inputStream, String fileName)
+  public RemoteReadRequestChain(FSDataInputStream inputStream, String remoteFileName, int generationNumber, Configuration conf)
   {
-    this(inputStream, fileName, new DirectBufferPool(), 100, new byte[100], new BookKeeperFactory());
+    this(inputStream, remoteFileName, generationNumber, new DirectBufferPool(), conf, new byte[100], new BookKeeperFactory());
   }
 
   public Long call()
@@ -86,9 +95,7 @@ public class RemoteReadRequestChain extends ReadRequestChain
     // Issue-53 : Open file with the right permissions
     File file = new File(localFile);
     if (!file.exists()) {
-      file.createNewFile();
-      file.setWritable(true, false);
-      file.setReadable(true, false);
+      throw new IOException(String.format("File does not exists %s", localFile));
     }
 
     FileChannel fileChannel = new FileOutputStream(new RandomAccessFile(file, "rw").getFD()).getChannel();
@@ -200,7 +207,7 @@ public class RemoteReadRequestChain extends ReadRequestChain
     try (RetryingPooledBookkeeperClient client = bookKeeperFactory.createBookKeeperClient(conf)) {
       for (ReadRequest readRequest : readRequests) {
         log.debug("Setting cached from : " + toBlock(readRequest.getBackendReadStart()) + " block to : " + (toBlock(readRequest.getBackendReadEnd() - 1) + 1));
-        client.setAllCached(remotePath, fileSize, lastModified, toBlock(readRequest.getBackendReadStart()), toBlock(readRequest.getBackendReadEnd() - 1) + 1);
+        client.setAllCached(remotePath, fileSize, lastModified, toBlock(readRequest.getBackendReadStart()), toBlock(readRequest.getBackendReadEnd() - 1) + 1, generationNumber);
       }
     }
     catch (Exception e) {

--- a/rubix-core/src/test/java/com/qubole/rubix/core/TestCachedReadRequestChain.java
+++ b/rubix-core/src/test/java/com/qubole/rubix/core/TestCachedReadRequestChain.java
@@ -31,6 +31,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.charset.Charset;
 
+import static com.qubole.rubix.spi.CacheUtil.UNKONWN_GENERATION_NUMBER;
 import static org.testng.Assert.assertTrue;
 
 /**
@@ -75,7 +76,7 @@ public class TestCachedReadRequestChain
     backendFile = new File(TEST_BACKEND_FILE);
 
     // Populate Cached File
-    String cachedLocalFile = CacheUtil.getLocalPath(backendFilePath.toString(), conf);
+    String cachedLocalFile = CacheUtil.getLocalPath(backendFilePath.toString(), conf, UNKONWN_GENERATION_NUMBER + 1);
     DataGen.populateFile(cachedLocalFile);
 
     factory = new BookKeeperFactory();
@@ -84,7 +85,7 @@ public class TestCachedReadRequestChain
   @AfterMethod
   public void cleanup() throws IOException
   {
-    File localFile = new File(CacheUtil.getLocalPath(backendFilePath.toString(), conf));
+    File localFile = new File(CacheUtil.getLocalPath(backendFilePath.toString(), conf, UNKONWN_GENERATION_NUMBER + 1));
     localFile.delete();
 
     backendFile.delete();
@@ -115,7 +116,7 @@ public class TestCachedReadRequestChain
   public void testCachedRead_WithNoLocalCachedFile() throws IOException
   {
     byte[] buffer = new byte[1000];
-    String localCachedFile = CacheUtil.getLocalPath(backendFilePath.toString(), conf);
+    String localCachedFile = CacheUtil.getLocalPath(backendFilePath.toString(), conf, UNKONWN_GENERATION_NUMBER + 1);
 
     CachedReadRequestChain cachedReadRequestChain = getCachedReadRequestChain(buffer);
 
@@ -139,7 +140,7 @@ public class TestCachedReadRequestChain
   public void testCachedRead_WithCorruptedLocalCachedFile_1() throws IOException
   {
     byte[] buffer = new byte[1000];
-    String localCachedFile = CacheUtil.getLocalPath(backendFilePath.toString(), conf);
+    String localCachedFile = CacheUtil.getLocalPath(backendFilePath.toString(), conf, UNKONWN_GENERATION_NUMBER + 1);
 
     CachedReadRequestChain cachedReadRequestChain = getCachedReadRequestChain(buffer);
 
@@ -162,7 +163,7 @@ public class TestCachedReadRequestChain
   public void testCachedRead_WithCorruptedLocalCachedFile_2() throws IOException
   {
     byte[] buffer = new byte[1000];
-    String localCachedFile = CacheUtil.getLocalPath(backendFilePath.toString(), conf);
+    String localCachedFile = CacheUtil.getLocalPath(backendFilePath.toString(), conf, UNKONWN_GENERATION_NUMBER + 1);
 
     CachedReadRequestChain cachedReadRequestChain = getCachedReadRequestChain(buffer);
 
@@ -186,10 +187,10 @@ public class TestCachedReadRequestChain
     MockCachingFileSystem fs = new MockCachingFileSystem();
     fs.initialize(backendFilePath.toUri(), conf);
 
-    String localCachedFile = CacheUtil.getLocalPath(backendFilePath.toString(), conf);
+    String localCachedFile = CacheUtil.getLocalPath(backendFilePath.toString(), conf, UNKONWN_GENERATION_NUMBER + 1);
     ReadRequest[] readRequests = getReadRequests(buffer);
 
-    CachedReadRequestChain cachedReadRequestChain = new CachedReadRequestChain(fs.getRemoteFileSystem(), backendFilePath.toString(), conf, factory);
+    CachedReadRequestChain cachedReadRequestChain = new CachedReadRequestChain(fs.getRemoteFileSystem(), backendFilePath.toString(), conf, factory, UNKONWN_GENERATION_NUMBER + 1);
     for (ReadRequest rr : readRequests) {
       cachedReadRequestChain.addReadRequest(rr);
     }

--- a/rubix-core/src/test/java/com/qubole/rubix/core/TestRemoteReadRequestChain.java
+++ b/rubix-core/src/test/java/com/qubole/rubix/core/TestRemoteReadRequestChain.java
@@ -13,6 +13,8 @@
 package com.qubole.rubix.core;
 
 import com.qubole.rubix.common.utils.DataGen;
+import com.qubole.rubix.spi.CacheConfig;
+import com.qubole.rubix.spi.CacheUtil;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.conf.Configuration;
@@ -29,8 +31,10 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.nio.charset.Charset;
 
+import static com.qubole.rubix.spi.CacheUtil.UNKONWN_GENERATION_NUMBER;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
+
 
 /**
  * Created by stagra on 15/1/16.
@@ -57,10 +61,18 @@ public class TestRemoteReadRequestChain
 
     FileSystem localFileSystem = new RawLocalFileSystem();
     Path backendFilePath = new Path(backendFileName);
+    Configuration conf = new Configuration();
+    CacheConfig.setCacheDataDirPrefix(conf, "/tmp");
+    CacheUtil.createCacheDirectories(conf);
     localFileSystem.initialize(backendFilePath.toUri(), new Configuration());
     fsDataInputStream = localFileSystem.open(backendFilePath);
+    localFileName = CacheUtil.getLocalPath(backendFileName, conf, UNKONWN_GENERATION_NUMBER + 1);
+    File file = new File(localFileName);
+    file.createNewFile();
+    file.setWritable(true, false);
+    file.setReadable(true, false);
 
-    remoteReadRequestChain = new RemoteReadRequestChain(fsDataInputStream, localFileName);
+    remoteReadRequestChain = new RemoteReadRequestChain(fsDataInputStream, backendFileName, UNKONWN_GENERATION_NUMBER + 1, conf);
   }
 
   @Test

--- a/rubix-spi/src/main/java/com/qubole/rubix/spi/CacheConfig.java
+++ b/rubix-spi/src/main/java/com/qubole/rubix/spi/CacheConfig.java
@@ -122,7 +122,7 @@ public class CacheConfig
   private static final int DEFAULT_KEY_POOL_DELTA_SIZE = 1;
   private static final int DEFAULT_POOL_MAX_WAIT_TIMEOUT = 5000; // ms
   private static final int DEFAULT_SCAVENGE_INTERVAL = 300000; // ms
-  private static final String DEFAULT_CACHE_METADATA_FILE_SUFFIX = "_mdfile";
+  private static final String DEFAULT_CACHE_METADATA_FILE_SUFFIX = "_mdfile_g";
   private static final String DEFAULT_DATA_CACHE_DIR_PREFIX = "/media/ephemeral";
   private static final String DEFAULT_DATA_CACHE_DIR_SUFFIX = "/fcache/";
   private static final boolean DEFAULT_DATA_CACHE_ENABLED = true;

--- a/rubix-spi/src/main/java/com/qubole/rubix/spi/LocalBookKeeperClient.java
+++ b/rubix-spi/src/main/java/com/qubole/rubix/spi/LocalBookKeeperClient.java
@@ -12,14 +12,14 @@
  */
 package com.qubole.rubix.spi;
 
-import com.qubole.rubix.spi.thrift.BlockLocation;
 import com.qubole.rubix.spi.thrift.BookKeeperService;
 import com.qubole.rubix.spi.thrift.CacheStatusRequest;
+import com.qubole.rubix.spi.thrift.CacheStatusResponse;
+import com.qubole.rubix.spi.thrift.ReadResponse;
 import com.qubole.rubix.spi.thrift.FileInfo;
 import com.qubole.rubix.spi.thrift.HeartbeatStatus;
 import org.apache.thrift.TException;
 
-import java.util.List;
 import java.util.Map;
 
 /**
@@ -36,16 +36,16 @@ public class LocalBookKeeperClient extends RetryingPooledBookkeeperClient
   }
 
   @Override
-  public List<BlockLocation> getCacheStatus(CacheStatusRequest request) throws TException
+  public CacheStatusResponse getCacheStatus(CacheStatusRequest request) throws TException
   {
     return bookKeeper.getCacheStatus(request);
   }
 
   @Override
-  public void setAllCached(final String remotePath, final long fileLength, final long lastModified, final long startBlock, final long endBlock)
+  public void setAllCached(final String remotePath, final long fileLength, final long lastModified, final long startBlock, final long endBlock, int generationNumber)
       throws TException
   {
-    bookKeeper.setAllCached(remotePath, fileLength, lastModified, startBlock, endBlock);
+    bookKeeper.setAllCached(remotePath, fileLength, lastModified, startBlock, endBlock, generationNumber);
   }
 
   @Override
@@ -56,7 +56,7 @@ public class LocalBookKeeperClient extends RetryingPooledBookkeeperClient
   }
 
   @Override
-  public boolean readData(String path, long readStart, int length, long fileSize, long lastModified, int clusterType)
+  public ReadResponse readData(String path, long readStart, int length, long fileSize, long lastModified, int clusterType)
           throws TException
   {
     return bookKeeper.readData(path, readStart, length, fileSize, lastModified, clusterType);

--- a/rubix-spi/src/main/java/com/qubole/rubix/spi/RetryingPooledBookkeeperClient.java
+++ b/rubix-spi/src/main/java/com/qubole/rubix/spi/RetryingPooledBookkeeperClient.java
@@ -18,9 +18,10 @@ package com.qubole.rubix.spi;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.qubole.rubix.spi.fop.Poolable;
-import com.qubole.rubix.spi.thrift.BlockLocation;
 import com.qubole.rubix.spi.thrift.BookKeeperService;
 import com.qubole.rubix.spi.thrift.CacheStatusRequest;
+import com.qubole.rubix.spi.thrift.CacheStatusResponse;
+import com.qubole.rubix.spi.thrift.ReadResponse;
 import com.qubole.rubix.spi.thrift.FileInfo;
 import com.qubole.rubix.spi.thrift.HeartbeatStatus;
 import org.apache.commons.logging.Log;
@@ -31,7 +32,6 @@ import org.apache.thrift.TServiceClient;
 import org.apache.thrift.protocol.TBinaryProtocol;
 import org.apache.thrift.transport.TTransport;
 
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
 
@@ -63,13 +63,13 @@ public class RetryingPooledBookkeeperClient
   }
 
   @Override
-  public List<BlockLocation> getCacheStatus(final CacheStatusRequest request) throws TException
+  public CacheStatusResponse getCacheStatus(final CacheStatusRequest request) throws TException
   {
-    return retryConnection(new Callable<List<BlockLocation>>()
+    return retryConnection(new Callable<CacheStatusResponse>()
     {
       @Override
-      public List<BlockLocation> call()
-              throws TException
+      public CacheStatusResponse call()
+          throws TException
       {
         return client().getCacheStatus(request);
       }
@@ -78,7 +78,7 @@ public class RetryingPooledBookkeeperClient
 
   @Override
   public void setAllCached(final String remotePath, final long fileLength, final long lastModified,
-          final long startBlock, final long endBlock) throws TException
+                           final long startBlock, final long endBlock, final int generationNumber) throws TException
   {
     retryConnection(new Callable<Void>()
     {
@@ -86,7 +86,7 @@ public class RetryingPooledBookkeeperClient
       public Void call()
               throws Exception
       {
-        client().setAllCached(remotePath, fileLength, lastModified, startBlock, endBlock);
+        client().setAllCached(remotePath, fileLength, lastModified, startBlock, endBlock, generationNumber);
         return null;
       }
     });
@@ -108,13 +108,13 @@ public class RetryingPooledBookkeeperClient
   }
 
   @Override
-  public boolean readData(final String path, final long readStart, final int length, final long fileSize, final long lastModified, final int clusterType)
+  public ReadResponse readData(final String path, final long readStart, final int length, final long fileSize, final long lastModified, final int clusterType)
           throws TException
   {
-    return retryConnection(new Callable<Boolean>()
+    return retryConnection(new Callable<ReadResponse>()
     {
       @Override
-      public Boolean call()
+      public ReadResponse call()
               throws TException
       {
         return client().readData(path, readStart, length, fileSize, lastModified, clusterType);

--- a/rubix-spi/src/main/thrift/bookkeeper.thrift
+++ b/rubix-spi/src/main/thrift/bookkeeper.thrift
@@ -34,15 +34,25 @@ struct CacheStatusRequest {
 		7: optional bool incrMetrics = false;
 }
 
+struct CacheStatusResponse {
+        1: required list<BlockLocation> blocks;
+        2: required int generationNumber;
+}
+
+struct ReadResponse {
+        1: required bool status;
+        2: required int generationNumber;
+}
+
 service BookKeeperService
 {
-    list<BlockLocation> getCacheStatus(1:CacheStatusRequest request)
+    CacheStatusResponse getCacheStatus(1:CacheStatusRequest request)
 
-    oneway void setAllCached(1:string remotePath, 2:long fileLength, 3:long lastModified, 4:long startBlock, 5:long endBlock)
+    oneway void setAllCached(1:string remotePath, 2:long fileLength, 3:long lastModified, 4:long startBlock, 5:long endBlock, 6:int generationNumber)
 
     map<string,double> getCacheMetrics()
 
-    bool readData(1:string path, 2:long readStart, 3:int length, 4:long fileSize, 5:long lastModified, 6:int clusterType)
+    ReadResponse readData(1:string path, 2:long readStart, 3:int length, 4:long fileSize, 5:long lastModified, 6:int clusterType)
 
     oneway void handleHeartbeat(1:string workerHostname, 2:HeartbeatStatus heartbeatStatus)
 

--- a/rubix-spi/src/test/java/com/qubole/rubix/spi/TestCacheUtil.java
+++ b/rubix-spi/src/test/java/com/qubole/rubix/spi/TestCacheUtil.java
@@ -32,6 +32,7 @@ import java.nio.file.attribute.PosixFilePermissions;
 import java.util.HashMap;
 import java.util.Set;
 
+import static com.qubole.rubix.spi.CacheUtil.UNKONWN_GENERATION_NUMBER;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
@@ -153,8 +154,8 @@ public class TestCacheUtil
 
     createCacheDirectoriesForTest(conf);
 
-    String localPath = CacheUtil.getLocalPath(remotePath, conf);
-    assertEquals(localPath, cacheTestDirPrefix + "0" + "/fcache/" + localRelPath, "Paths not equal!");
+    String localPath = CacheUtil.getLocalPath(remotePath, conf, UNKONWN_GENERATION_NUMBER + 1);
+    assertEquals(localPath, getExpectedPath(cacheTestDirPrefix, localRelPath, false), "Paths not equal!");
   }
 
   @Test
@@ -167,8 +168,8 @@ public class TestCacheUtil
 
     createCacheDirectoriesForTest(conf);
 
-    String localPath = CacheUtil.getLocalPath(localRelPath, conf);
-    assertEquals(localPath, cacheTestDirPrefix + "0" + "/fcache/" + localRelPath, "Paths not equal!");
+    String localPath = CacheUtil.getLocalPath(localRelPath, conf, UNKONWN_GENERATION_NUMBER + 1);
+    assertEquals(localPath, getExpectedPath(cacheTestDirPrefix, localRelPath, false), "Paths not equal!");
   }
 
   @Test
@@ -176,13 +177,13 @@ public class TestCacheUtil
   {
     String localRelPath = "testbucket";
     CacheConfig.setCacheDataDirPrefix(conf, cacheTestDirPrefix);
-    CacheConfig.setCacheDataDirSuffix(conf, "/fcache/");
+    CacheConfig.setCacheDataDirSuffix(conf, "/fcache");
     CacheConfig.setMaxDisks(conf, 1);
 
     createCacheDirectoriesForTest(conf);
 
-    String localPath = CacheUtil.getLocalPath(localRelPath, conf);
-    assertEquals(localPath, cacheTestDirPrefix + "0" + "/fcache//" + localRelPath, "Paths not equal!");
+    String localPath = CacheUtil.getLocalPath(localRelPath, conf, UNKONWN_GENERATION_NUMBER + 1);
+    assertEquals(localPath, getExpectedPath(cacheTestDirPrefix, localRelPath, false), "Paths not equal!");
   }
 
   @Test
@@ -196,13 +197,13 @@ public class TestCacheUtil
 
     createCacheDirectoriesForTest(conf);
 
-    String localPath = CacheUtil.getMetadataFilePath(remotePath, conf);
-    assertEquals(localPath, cacheTestDirPrefix + "0" + "/fcache/" + localRelPath + "_mdfile", "Paths not equal!");
+    String localPath = CacheUtil.getMetadataFilePath(remotePath, conf, UNKONWN_GENERATION_NUMBER + 1);
+    assertEquals(localPath, getExpectedPath(cacheTestDirPrefix, localRelPath, true), "Paths not equal!");
 
     localRelPath = "tesbucket/123";
     remotePath = "s3://" + localRelPath;
-    localPath = CacheUtil.getMetadataFilePath(remotePath, conf);
-    assertEquals(localPath, cacheTestDirPrefix + "0" + "/fcache/" + localRelPath + "_mdfile", "Paths not equal!");
+    localPath = CacheUtil.getMetadataFilePath(remotePath, conf, UNKONWN_GENERATION_NUMBER + 1);
+    assertEquals(localPath, getExpectedPath(cacheTestDirPrefix, localRelPath, true), "Paths not equal!");
   }
 
   @Test
@@ -216,8 +217,8 @@ public class TestCacheUtil
 
     createCacheDirectoriesForTest(conf);
 
-    String localPath = CacheUtil.getMetadataFilePath(remotePath, conf);
-    assertEquals(localPath, cacheTestDirPrefix + "0" + "/fcache/" + localRelPath + "_mdfile", "Paths not equal!");
+    String localPath = CacheUtil.getMetadataFilePath(remotePath, conf, UNKONWN_GENERATION_NUMBER + 1);
+    assertEquals(localPath, getExpectedPath(cacheTestDirPrefix, localRelPath, true), "Paths not equal!");
   }
 
   @Test
@@ -231,8 +232,18 @@ public class TestCacheUtil
 
     createCacheDirectoriesForTest(conf);
 
-    String localPath = CacheUtil.getMetadataFilePath(remotePath, conf);
-    assertEquals(localPath, cacheTestDirPrefix + "0" + "/fcache/" + localRelPath + "_mdfile", "Paths not equal!");
+    String localPath = CacheUtil.getMetadataFilePath(remotePath, conf, UNKONWN_GENERATION_NUMBER + 1);
+    assertEquals(localPath, getExpectedPath(cacheTestDirPrefix, localRelPath, true), "Paths not equal!");
+  }
+
+  String getExpectedPath(String cacheTestDirPrefix, String localRelPath, boolean mdFile)
+  {
+    String metadataPrefix = "";
+    if (mdFile)
+    {
+      metadataPrefix = "_mdfile";
+    }
+    return String.format("%s0/fcache/%s%s_g%d", cacheTestDirPrefix, localRelPath, metadataPrefix, UNKONWN_GENERATION_NUMBER + 1);
   }
 
   @Test

--- a/rubix-tests/src/test/java/com/qubole/rubix/tests/TestCachingInputStream.java
+++ b/rubix-tests/src/test/java/com/qubole/rubix/tests/TestCachingInputStream.java
@@ -43,6 +43,7 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Arrays;
 
+import static com.qubole.rubix.spi.CacheUtil.UNKONWN_GENERATION_NUMBER;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
@@ -152,10 +153,10 @@ public class TestCachingInputStream
     File file = new File(backendFileName);
     file.delete();
 
-    File mdFile = new File(CacheUtil.getMetadataFilePath(backendPath.toString(), conf));
+    File mdFile = new File(CacheUtil.getMetadataFilePath(backendPath.toString(), conf, UNKONWN_GENERATION_NUMBER + 1));
     mdFile.delete();
 
-    File localFile = new File(CacheUtil.getLocalPath(backendPath.toString(), conf));
+    File localFile = new File(CacheUtil.getLocalPath(backendPath.toString(), conf, UNKONWN_GENERATION_NUMBER + 1));
     localFile.delete();
 
     conf.clear();

--- a/rubix-tests/src/test/java/com/qubole/rubix/tests/TestGenerationNumber.java
+++ b/rubix-tests/src/test/java/com/qubole/rubix/tests/TestGenerationNumber.java
@@ -1,0 +1,510 @@
+/**
+ * Copyright (c) 2019. Qubole Inc
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License. See accompanying LICENSE file.
+ */
+package com.qubole.rubix.tests;
+
+import com.codahale.metrics.MetricRegistry;
+import com.qubole.rubix.bookkeeper.BookKeeperServer;
+import com.qubole.rubix.bookkeeper.LocalDataTransferServer;
+import com.qubole.rubix.bookkeeper.utils.DiskUtils;
+import com.qubole.rubix.common.utils.DataGen;
+import com.qubole.rubix.common.utils.DeleteFileVisitor;
+import com.qubole.rubix.core.CachingFileSystemStats;
+import com.qubole.rubix.core.CachingInputStream;
+import com.qubole.rubix.core.MockCachingFileSystem;
+import com.qubole.rubix.core.NonLocalReadRequestChain;
+import com.qubole.rubix.core.ReadRequest;
+import com.qubole.rubix.spi.BookKeeperFactory;
+import com.qubole.rubix.spi.CacheConfig;
+import com.qubole.rubix.spi.CacheUtil;
+import com.qubole.rubix.spi.ClusterType;
+import com.qubole.rubix.spi.RetryingPooledBookkeeperClient;
+import com.qubole.rubix.spi.thrift.CacheStatusRequest;
+import com.qubole.rubix.spi.thrift.CacheStatusResponse;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.RawLocalFileSystem;
+import org.apache.thrift.shaded.TException;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.BiFunction;
+
+import static com.qubole.rubix.spi.CacheUtil.UNKONWN_GENERATION_NUMBER;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+public class TestGenerationNumber
+{
+  private static final String testDirectoryPrefix = System.getProperty("java.io.tmpdir") + "/tmp/testPath";
+  private static final long TEST_LAST_MODIFIED = 1514764800; // 2018-01-01T00:00:00
+  private static final long TEST_FILE_LENGTH = 5000;
+  private static final String testDirectory = testDirectoryPrefix + "dir0";
+
+  private static final Log log = LogFactory.getLog(TestGenerationNumber.class);
+
+  int blockSize = 100;
+  String backendFileName = testDirectoryPrefix + "backendFile";
+  File backendFile;
+  Path backendPath = new Path("file:///" + backendFileName.substring(1));
+
+  private BookKeeperServer bookKeeperServer;
+  private BookKeeperFactory bookKeeperFactory;
+
+  MockCachingFileSystem fs;
+  final Configuration conf = new Configuration();
+
+  @BeforeClass
+  public static void setupClass()
+      throws IOException
+  {
+    log.info(testDirectory);
+    Files.createDirectories(Paths.get(testDirectory));
+  }
+
+  @AfterClass
+  public static void tearDownClass()
+      throws IOException
+  {
+    Files.walkFileTree(Paths.get(testDirectory), new DeleteFileVisitor());
+    Files.deleteIfExists(Paths.get(testDirectory));
+  }
+
+  @BeforeMethod
+  public void setup()
+      throws Exception
+  {
+    CacheConfig.setOnMaster(conf, true);
+    CacheConfig.setIsStrictMode(conf, true);
+    CacheConfig.setBookKeeperServerPort(conf, 3456);
+    CacheConfig.setDataTransferServerPort(conf, 2222);
+    CacheConfig.setBlockSize(conf, blockSize);
+    CacheConfig.setCacheDataDirPrefix(conf, testDirectoryPrefix + "dir");
+    CacheConfig.setMaxDisks(conf, 1);
+    CacheConfig.setIsParallelWarmupEnabled(conf, false);
+    CacheConfig.setCleanupFilesDuringStart(conf, false);
+    bookKeeperFactory = new BookKeeperFactory();
+    startServer();
+    fs = new MockCachingFileSystem();
+    fs.initialize(backendPath.toUri(), conf);
+    // Populate File
+    DataGen.populateFile(backendFileName);
+    backendFile = new File(backendFileName);
+  }
+
+  private CachingInputStream createCachingStream(Configuration conf)
+      throws IOException
+  {
+    FileSystem localFileSystem = new RawLocalFileSystem();
+    Path backendFilePath = new Path(backendFileName);
+    localFileSystem.initialize(backendFilePath.toUri(), new Configuration());
+    CacheConfig.setBlockSize(conf, blockSize);
+
+    // This should be after server comes up else client could not be created
+    return new CachingInputStream(backendPath, conf,
+        new CachingFileSystemStats(), ClusterType.TEST_CLUSTER_MANAGER,
+        new BookKeeperFactory(), localFileSystem,
+        CacheConfig.getBlockSize(conf), null);
+  }
+
+  /**
+   * Verify that correct data is read when invalidation is triggered simultaneously
+   * with parallel warmup disabled.
+   */
+  @Test
+  void testReadWithInvalidationsWithoutParalleWarmUp()
+      throws Exception
+  {
+    testReadWithInvalidationHelper(getLocalCacheReader(conf));
+  }
+
+  /**
+   * Verify that correct data is read when invalidation is triggered simultaneously
+   * with parallel warmup enabled.
+   */
+  @Test
+  void testReadWithInvalidationsWithParallelWarmUp()
+      throws Exception
+  {
+    CacheConfig.setIsParallelWarmupEnabled(conf, true);
+    CacheConfig.setRemoteFetchProcessInterval(conf, 500);
+    restartServer();
+    testReadWithInvalidationHelper(getLocalCacheReader(conf));
+  }
+
+  /**
+   * Verify that correct data is read via non local RRC when invalidation is triggered simultaneously
+   * with parallel warmup disabled.
+   */
+  @Test
+  void testNonLocalReadWithInvalidationsWithoutParalleWarmUp()
+      throws Exception
+  {
+    startLDS();
+    testReadWithInvalidationHelper(getNonLocalCacheReader(conf));
+  }
+
+  /**
+   * Verify that correct data is read via non local RRC when invalidation is triggered simultaneously
+   * with parallel warmup enabled.
+   */
+  @Test
+  void testNonLocalReadWithInvalidationsWithParallelWarmUp()
+      throws Exception
+  {
+    startLDS();
+    CacheConfig.setIsParallelWarmupEnabled(conf, true);
+    CacheConfig.setRemoteFetchProcessInterval(conf, 500);
+    restartServer();
+    testReadWithInvalidationHelper(getNonLocalCacheReader(conf));
+  }
+
+  private void startLDS()
+      throws InterruptedException
+  {
+    Thread localDataTransferServer;
+    localDataTransferServer = new Thread()
+    {
+      public void run()
+      {
+        LocalDataTransferServer.startServer(conf, new MetricRegistry());
+      }
+    };
+    localDataTransferServer.start();
+    while (!LocalDataTransferServer.isServerUp()) {
+      Thread.sleep(200);
+      log.info("Waiting for Local Data Transfer Server to come up");
+    }
+  }
+
+  private BiFunction<byte[], Integer, Integer> getLocalCacheReader(Configuration conf)
+  {
+    return (buffer, readLen) -> {
+      try {
+        return createCachingStream(conf).read(buffer, 0, readLen);
+      }
+      catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+    };
+  }
+
+  private BiFunction<byte[], Integer, Integer> getNonLocalCacheReader(Configuration conf)
+  {
+    return (buffer, readLength) ->
+    {
+      NonLocalReadRequestChain requestChain = new NonLocalReadRequestChain("localhost", backendFile.length(),
+          backendFile.lastModified(), conf, fs.getRemoteFileSystem(), backendPath.toString(),
+          ClusterType.TEST_CLUSTER_MANAGER.ordinal(), false, null);
+
+      ReadRequest readRequest = new ReadRequest(0, 100, 0, readLength, buffer, 0, backendFile.length());
+      requestChain.addReadRequest(readRequest);
+      requestChain.lock();
+      try {
+        return Math.toIntExact(requestChain.call());
+      }
+      catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+    };
+  }
+
+  void testReadWithInvalidationHelper(BiFunction<byte[], Integer, Integer> reader)
+      throws Exception
+  {
+    int maxReadTasks  = 200;
+    final RetryingPooledBookkeeperClient client = getBookKeeperClient();
+    AtomicBoolean testDone = new AtomicBoolean();
+    Thread invalidateRequest = new Thread(() -> {
+      for (int i = 1; i < 100; i++)
+      {
+        try {
+          if (testDone.get()) {
+            return;
+          }
+          client.invalidateFileMetadata(backendPath.toString());
+          Thread.sleep(500);
+        } catch (Exception e) {
+          throw new RuntimeException(e);
+        }
+      }
+    });
+
+    ExecutorService service = Executors.newFixedThreadPool(20);
+    List<Future> readtasks = new ArrayList<>();
+    // submit the read task for execution
+    for(int id = 0; id < maxReadTasks; id++)
+    {
+      int readLength = new Random().nextInt(100);
+      readtasks.add(service.submit(new ReadCallable(readLength, reader)));
+    }
+    invalidateRequest.start();
+    for (int id = 0; id < maxReadTasks; id++) {
+      Future<Data> result = readtasks.get(id);
+      Data data = result.get();
+      assertions(data.getReadSize(), data.getexpectedReadSize(), data.getBuffer());
+    }
+    testDone.set(true);
+    invalidateRequest.join();
+  }
+
+  class ReadCallable implements Callable<Data>
+  {
+    int readLength;
+    BiFunction<byte[], Integer, Integer> reader;
+
+    ReadCallable(int readLength, BiFunction<byte[], Integer, Integer> reader)
+    {
+      this.readLength = readLength;
+      this.reader = reader;
+    }
+
+    @Override
+    public Data call()
+    {
+      try {
+        byte[] buffer = new byte[readLength];
+        int readSize = reader.apply(buffer, readLength);
+        return new Data(buffer, readSize, readLength);
+      }
+      catch (Exception e)
+      {
+        throw new RuntimeException(e);
+      }
+    }
+  }
+
+  class Data
+  {
+    byte[] buffer;
+    int readSize;
+    int expectedReadSize;
+    public Data(byte[] buffer, int readSize, int expectedReadSize)
+    {
+      this.buffer = buffer;
+      this.readSize = readSize;
+      this.expectedReadSize = expectedReadSize;
+    }
+
+    public byte[] getBuffer()
+    {
+      return buffer;
+    }
+
+    public int getReadSize()
+    {
+      return readSize;
+    }
+
+    public int getexpectedReadSize()
+    {
+      return expectedReadSize;
+    }
+  }
+
+  /**
+   * Verify that generation number get incremented after each invalidation call
+   */
+  @Test
+  void testGenerationNumberIncrement()
+      throws Exception
+  {
+    RetryingPooledBookkeeperClient client = getBookKeeperClient();
+    int readOffset = 0;
+    int readLength = 2000;
+    client.readData(backendPath.toString(), readOffset, readLength, TEST_FILE_LENGTH, TEST_LAST_MODIFIED, ClusterType.TEST_CLUSTER_MANAGER.ordinal());
+    client.invalidateFileMetadata(backendPath.toString());
+    CacheStatusRequest request = new CacheStatusRequest(backendPath.toString(),
+        TEST_FILE_LENGTH,
+        TEST_LAST_MODIFIED,
+        0,
+        20).setClusterType(ClusterType.TEST_CLUSTER_MANAGER.ordinal());
+    int generationNumber = client.getCacheStatus(request).getGenerationNumber();
+    assertEquals(generationNumber, UNKONWN_GENERATION_NUMBER + 2, "Invalid generation number");
+  }
+
+  /**
+   * Verify that correct generation number is returned during startup of BKS
+   */
+  @Test
+  void testGenerationNumberDuringStartUp()
+      throws Exception
+  {
+    int generationNumber = 5;
+    // create files till generation Number = 5
+    creatLocalFilesOnCache(generationNumber);
+    testGenerationNumberDuringStartUpHelper(generationNumber, false);
+    restartServer();
+    creatLocalFilesOnCache(generationNumber);
+    new File(CacheUtil.getMetadataFilePath(backendPath.toString(), conf, generationNumber)).delete();
+    testGenerationNumberDuringStartUpHelper(generationNumber, true);
+    // clean up required during startup
+    CacheConfig.setCleanupFilesDuringStart(conf, true);
+    restartServer();
+    creatLocalFilesOnCache(generationNumber);
+    testGenerationNumberDuringStartUpHelper(generationNumber, true);
+  }
+
+  void testGenerationNumberDuringStartUpHelper(int generationNumber, boolean misssingFileOrCleanUpRequired)
+      throws TException
+  {
+    RetryingPooledBookkeeperClient client = getBookKeeperClient();
+    CacheStatusRequest request = new CacheStatusRequest(backendPath.toString(),
+        TEST_FILE_LENGTH,
+        TEST_LAST_MODIFIED,
+        0,
+        20).setClusterType(ClusterType.TEST_CLUSTER_MANAGER.ordinal());
+    CacheStatusResponse response = client.getCacheStatus(request);
+    if (!misssingFileOrCleanUpRequired)
+    {
+      // Both datafile and mdfile exists with generationNumber on disk so we should get generationNumber in response
+      assertEquals(response.getGenerationNumber(), generationNumber, "Unexpected generation number");
+    }
+    else
+    {
+      // datafile exists with generationNumber on disk but without mdFile or cleanup required
+      // we should get generationNumber + 1 in response
+      assertEquals(response.getGenerationNumber(), generationNumber + 1, "Unexpected generation number");
+    }
+  }
+
+  /**
+   * Verify that correct generation number is returned after cache warmup
+   */
+  @Test
+  void testGenerationNumberAfterCacheWarmUp() throws Exception {
+    int generationNumber = 5;
+    RetryingPooledBookkeeperClient client = getBookKeeperClient();
+    CacheStatusRequest request = new CacheStatusRequest(backendPath.toString(),
+        TEST_FILE_LENGTH,
+        TEST_LAST_MODIFIED,
+        0,
+        20).setClusterType(ClusterType.TEST_CLUSTER_MANAGER.ordinal());
+    // warm up the cache
+    client.getCacheStatus(request);
+    // invalidate the remote path
+    client.invalidateFileMetadata(backendPath.toString());
+    // create files till generation Number = 5
+    creatLocalFilesOnCache(generationNumber);
+    CacheStatusResponse response = client.getCacheStatus(request);
+    assertEquals(response.getGenerationNumber(), generationNumber + 1, "Unexpected generation number");
+  }
+
+  RetryingPooledBookkeeperClient getBookKeeperClient()
+      throws TException
+  {
+    RetryingPooledBookkeeperClient client = bookKeeperFactory.createBookKeeperClient("localhost", conf);
+    return client;
+  }
+
+  void creatLocalFilesOnCache(int generationNumber)
+      throws IOException
+  {
+    File mdFile = null, localFile = null;
+    for(int genNumber = 1; genNumber <= generationNumber; genNumber++)
+    {
+      mdFile = new File(CacheUtil.getMetadataFilePath(backendPath.toString(), conf, genNumber));
+      mdFile.createNewFile();
+      localFile = new File(CacheUtil.getLocalPath(backendPath.toString(), conf, genNumber));
+      localFile.createNewFile();
+    }
+  }
+
+  @AfterMethod
+  public void cleanup()
+      throws IOException
+  {
+    // make sure directory is empty before running test
+    try {
+      int numDisks = CacheConfig.getCacheMaxDisks(conf);
+      String dirSuffix = CacheConfig.getCacheDataDirSuffix(conf);
+      List<String> dirPrefixList = CacheUtil.getDirPrefixList(conf);
+
+      for (String dirPrefix : dirPrefixList) {
+        for (int i = 0; i < numDisks; i++) {
+          java.nio.file.Path path = Paths.get(dirPrefix + i, dirSuffix, "*");
+          DiskUtils.clearDirectory(path.toString());
+        }
+
+        java.nio.file.Path path = Paths.get(dirPrefix, dirSuffix, "*");
+        DiskUtils.clearDirectory(path.toString());
+      }
+    }
+    catch (IOException ex) {
+      log.error("Could not clean up the old cached files", ex);
+    }
+    stopServer();
+    conf.clear();
+  }
+
+  private void stopServer()
+  {
+    if (bookKeeperServer != null)
+    {
+      bookKeeperServer.stopServer();
+    }
+    LocalDataTransferServer.stopServer();
+  }
+
+  private void startServer()
+      throws InterruptedException
+  {
+    bookKeeperServer = new BookKeeperServer();
+    Thread thread = new Thread()
+    {
+      public void run()
+      {
+        bookKeeperServer.startServer(conf, new MetricRegistry());
+      }
+    };
+    thread.start();
+    while (!bookKeeperServer.isServerUp())
+    {
+      Thread.sleep(200);
+      log.info("Waiting for BookKeeper Server to come up");
+    }
+  }
+
+  private void restartServer()
+      throws InterruptedException
+  {
+    stopServer();
+    startServer();
+  }
+
+  private void assertions(int readSize, int expectedReadSize, byte[] outputBuffer)
+  {
+    String expectedOutput = DataGen.generateContent().substring(0, expectedReadSize);
+    assertTrue(readSize == expectedReadSize, "Wrong amount of data read " + readSize + " was expecting " + expectedReadSize);
+    String output = new String(outputBuffer, Charset.defaultCharset());
+    assertTrue(expectedOutput.equals(output), "Wrong data read, expected\n" + expectedOutput + "\nBut got\n" + output);
+  }
+}

--- a/rubix-tests/src/test/java/com/qubole/rubix/tests/TestNonLocalReadRequestChain.java
+++ b/rubix-tests/src/test/java/com/qubole/rubix/tests/TestNonLocalReadRequestChain.java
@@ -55,6 +55,7 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.List;
 
+import static com.qubole.rubix.spi.CacheUtil.UNKONWN_GENERATION_NUMBER;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
@@ -341,7 +342,7 @@ public class TestNonLocalReadRequestChain
 
     CacheStatusRequest request = new CacheStatusRequest(backendPath.toString(), backendFile.length(), backendFile.lastModified(),
         0, endBlock).setClusterType(ClusterType.TEST_CLUSTER_MANAGER.ordinal());
-    List<BlockLocation> blockLocations = client.getCacheStatus(request);
+    List<BlockLocation> blockLocations = client.getCacheStatus(request).getBlocks();
 
     for (BlockLocation location : blockLocations) {
       if (location.getLocation() != Location.CACHED) {
@@ -356,10 +357,10 @@ public class TestNonLocalReadRequestChain
   {
     stopAllServers();
 
-    File mdFile = new File(CacheUtil.getMetadataFilePath(backendPath.toString(), conf));
+    File mdFile = new File(CacheUtil.getMetadataFilePath(backendPath.toString(), conf, UNKONWN_GENERATION_NUMBER + 1));
     mdFile.delete();
 
-    File localFile = new File(CacheUtil.getLocalPath(backendPath.toString(), conf));
+    File localFile = new File(CacheUtil.getLocalPath(backendPath.toString(), conf, UNKONWN_GENERATION_NUMBER + 1));
     localFile.delete();
     backendFile.delete();
 


### PR DESCRIPTION
Tested the changes by making invalidation happen by : 
- Setting cache timeout  (KEY_DATA_CACHE_EXPIRY_AFTER_WRITE) to a K second and firing long-running query. Invalidation happens at regular interval and the query does not fail. (generation number increases)
- Setting the size of the cache  (KEY_MAX_CACHE_SIZE) to K MB and firing the query to scan data more than K MB from 2-3 tables. In this case, also invalidation happens and verified queries do not fail.
- Manually deleting the cache directory while a query was running, verified query does not fail and generation number increases.
grepped the log directory to check any errors too.