### PR TITLE
Reduce logging level for FileNotFoundExceptions

### DIFF
--- a/rubix-bookkeeper/src/main/java/com/qubole/rubix/bookkeeper/FileDownloader.java
+++ b/rubix-bookkeeper/src/main/java/com/qubole/rubix/bookkeeper/FileDownloader.java
@@ -33,6 +33,7 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.util.DirectBufferPool;
 
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
@@ -213,7 +214,11 @@ class FileDownloader
         }
       }
       catch (ExecutionException | InterruptedException ex) {
-        log.error(ex);
+        if (ex.getCause() instanceof FileNotFoundException) {
+          log.info("Could not process download request: " + ex.getMessage());
+        } else {
+          log.error("Could not process download request", ex);
+        }
         requestChain.cancel();
       }
     }


### PR DESCRIPTION
In parallel warmup mode file might be gone by the
time Rubix tries to download it. Since this is something
that is expected, it doesn't need to be logged as error.