### PR TITLE
Add release notes in docs

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,17 +1,14 @@
-.. Rubix documentation master file, created by
-   sphinx-quickstart on Fri Sep  1 12:04:37 2017.
-   You can adapt this file completely to your liking, but it should at least
-   contain the root `toctree` directive.
-
-Welcome to RubiX's documentation!
-=================================
+###################
+Rubix Documentation
+###################
 
 RubiX is a light-weight data caching framework that can be used by Big-Data engines.
 RubiX can be extended to support any engine that accesses data in cloud stores using Hadoop FileSystem interface via plugins.
-Using the same plugins, RubiX can also be extended to be used with any cloud store
+Using the same plugins, RubiX can also be extended to be used with any cloud store.
 
 .. toctree::
    :maxdepth: 2
+   :numbered: 2
    :caption: Contents:
 
    intro.md
@@ -19,10 +16,5 @@ Using the same plugins, RubiX can also be extended to be used with any cloud sto
    configuration.rst
    metrics.rst
    contrib/index.rst
+   release/index.rst
 
-Indices and tables
-==================
-
-* :ref:`genindex`
-* :ref:`modindex`
-* :ref:`search`

--- a/docs/release/index.rst
+++ b/docs/release/index.rst
@@ -1,0 +1,10 @@
+=============
+Release Notes
+=============
+
+.. toctree::
+   :numbered: 2
+   :glob:
+   :reversed:
+
+   release_notes/*

--- a/docs/release/release_notes/release-0.3.10.rst
+++ b/docs/release/release_notes/release-0.3.10.rst
@@ -1,0 +1,10 @@
+==============
+Release 0.3.10
+==============
+
+* Bypass getFileInfo network call when staleness check is enabled
+* Remove runtime dependencies to fix ClassNotFound errors in Embedded mode
+* Ensure InputStream for DirectReadRequestChain is always closed
+* Make CachingFileSystem extend FilterFileSystem
+* Fix connection leak in RetryingPooledThriftClient that happens if a connection terminates with an exception
+

--- a/docs/release/release_notes/release-0.3.11.rst
+++ b/docs/release/release_notes/release-0.3.11.rst
@@ -1,0 +1,6 @@
+==============
+Release 0.3.11
+==============
+
+* Fix a regression from 0.3.10 that caused wrong BlockLocations to be returned in CachingFileSystem#listLocatedStatus
+* Presto's native NodeManager can now be used as cluster manager in embedded mode


### PR DESCRIPTION
This is how main page of docs looks like now:
<img width="1423" alt="Screenshot 2020-06-11 at 1 33 02 PM" src="https://user-images.githubusercontent.com/7426795/84361180-e458ab00-abe8-11ea-8f6b-7500574292a6.png">

This is how the release notes page looks like now:
<img width="1440" alt="Screenshot 2020-06-11 at 1 33 15 PM" src="https://user-images.githubusercontent.com/7426795/84361209-f20e3080-abe8-11ea-9344-01d12344c281.png">
