### PR TITLE
Fix over-estimation of Cache size

### DIFF
--- a/rubix-bookkeeper/src/main/java/com/qubole/rubix/bookkeeper/BookKeeper.java
+++ b/rubix-bookkeeper/src/main/java/com/qubole/rubix/bookkeeper/BookKeeper.java
@@ -59,7 +59,6 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
-import java.nio.ByteBuffer;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -73,6 +72,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
 import static com.google.common.base.Preconditions.checkState;
+import static com.qubole.rubix.spi.utils.DataSizeUnits.BYTES;
 import static com.qubole.rubix.common.metrics.BookKeeperMetrics.CacheMetric.CACHE_AVAILABLE_SIZE_GAUGE;
 import static com.qubole.rubix.common.metrics.BookKeeperMetrics.CacheMetric.CACHE_EVICTION_COUNT;
 import static com.qubole.rubix.common.metrics.BookKeeperMetrics.CacheMetric.CACHE_EXPIRY_COUNT;
@@ -626,7 +626,7 @@ public abstract class BookKeeper implements BookKeeperService.Iface
     for (int d = 0; d < cacheDiskCount; d++) {
       avail += new File(CacheUtil.getDirPath(d, conf)).getUsableSpace();
     }
-    avail = DiskUtils.bytesToMB(avail);
+    avail = BYTES.toMB(avail);
     log.info("total free space " + avail + "MB");
 
     // In corner cases evictions might not make enough space for new entries

--- a/rubix-bookkeeper/src/main/java/com/qubole/rubix/bookkeeper/FileDownloader.java
+++ b/rubix-bookkeeper/src/main/java/com/qubole/rubix/bookkeeper/FileDownloader.java
@@ -18,7 +18,6 @@ import com.codahale.metrics.MetricRegistry;
 import com.google.common.collect.Range;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
-import com.qubole.rubix.bookkeeper.utils.DiskUtils;
 import com.qubole.rubix.common.metrics.BookKeeperMetrics;
 import com.qubole.rubix.core.ReadRequest;
 import com.qubole.rubix.spi.CacheConfig;
@@ -46,6 +45,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.ThreadPoolExecutor;
 
+import static com.qubole.rubix.spi.utils.DataSizeUnits.BYTES;
 import static com.qubole.rubix.spi.CommonUtilities.toBlockStartPosition;
 import static com.qubole.rubix.spi.CommonUtilities.toEndBlock;
 import static com.qubole.rubix.spi.CommonUtilities.toStartBlock;
@@ -217,7 +217,7 @@ class FileDownloader
         requestChain.cancel();
       }
     }
-    long dataDownloadedInMB = DiskUtils.bytesToMB(sizeRead);
+    long dataDownloadedInMB = BYTES.toMB(sizeRead);
     this.totalMBDownloaded.inc(dataDownloadedInMB);
     return sizeRead;
   }

--- a/rubix-bookkeeper/src/main/java/com/qubole/rubix/bookkeeper/FileMetadata.java
+++ b/rubix-bookkeeper/src/main/java/com/qubole/rubix/bookkeeper/FileMetadata.java
@@ -28,6 +28,7 @@ import java.io.RandomAccessFile;
 import java.util.OptionalInt;
 import java.util.concurrent.locks.Lock;
 
+import static com.qubole.rubix.spi.utils.DataSizeUnits.BYTES;
 import static com.qubole.rubix.spi.CacheConfig.getBlockSize;
 
 /**
@@ -250,6 +251,6 @@ public class FileMetadata
   public int getWeight(Configuration conf)
   {
     // this will return the current downloaded size of the file as weight.
-    return (int) (currentFileSize / 1024 / 1024);
+    return (int) BYTES.toMB(currentFileSize);
   }
 }

--- a/rubix-bookkeeper/src/main/java/com/qubole/rubix/bookkeeper/FileMetadata.java
+++ b/rubix-bookkeeper/src/main/java/com/qubole/rubix/bookkeeper/FileMetadata.java
@@ -248,9 +248,9 @@ public class FileMetadata
     }
   }
 
-  public int getWeight(Configuration conf)
+  // Returns the current downloaded fileSize in KB
+  public int getWeight()
   {
-    // this will return the current downloaded size of the file as weight.
-    return (int) BYTES.toMB(currentFileSize);
+    return Math.toIntExact(BYTES.toKB(currentFileSize));
   }
 }

--- a/rubix-bookkeeper/src/main/java/com/qubole/rubix/bookkeeper/utils/DiskUtils.java
+++ b/rubix-bookkeeper/src/main/java/com/qubole/rubix/bookkeeper/utils/DiskUtils.java
@@ -101,14 +101,4 @@ public class DiskUtils
       return -1L;
     }
   }
-
-  public static int getUsedSpaceMB(Configuration conf)
-  {
-    long used = 0;
-    for (int d = 0; d < CacheUtil.getCacheDiskCount(conf); d++) {
-      File localPath = new File(CacheUtil.getDirPath(d, conf));
-      used += localPath.getTotalSpace() - localPath.getUsableSpace();
-    }
-    return (int) BYTES.toMB(used);
-  }
 }

--- a/rubix-bookkeeper/src/main/java/com/qubole/rubix/bookkeeper/utils/DiskUtils.java
+++ b/rubix-bookkeeper/src/main/java/com/qubole/rubix/bookkeeper/utils/DiskUtils.java
@@ -24,6 +24,9 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.util.Map;
 
+import static com.qubole.rubix.spi.utils.DataSizeUnits.BYTES;
+import static com.qubole.rubix.spi.utils.DataSizeUnits.KILOBYTES;
+
 /**
  * Created by stagra on 29/1/16.
  */
@@ -34,30 +37,6 @@ public class DiskUtils
   private DiskUtils()
   {
     //
-  }
-
-  /**
-   * Convert bytes to MB.
-   *
-   * @param bytes   The number of bytes.
-   * @return the number of bytes as MB.
-   */
-  public static long bytesToMB(long bytes)
-  {
-    return (bytes / 1024 / 1024);
-  }
-
-  // Return actual size of a sparse file in bytes
-  public static long getActualSize(String path)
-      throws IOException
-  {
-    File file = new File(path);
-    String cmd = "ls -s " + path + " | cut -d ' ' -f 1";
-    ShellExec se = new ShellExec(cmd);
-    log.debug("Running: " + cmd);
-    ShellExec.CommandResult cr = se.runCmd();
-    long size = Long.parseLong(cr.getOut().trim());
-    return size * 1024;
   }
 
   public static void clearDirectory(String path) throws IOException
@@ -114,7 +93,7 @@ public class DiskUtils
       log.error(String.format("Exception while calculating the size of the folder %s with exception : %s", dirname.toString(), e.toString()));
     }
     try {
-      return Long.parseLong(output.toString().split("\\s+")[0]) / 1024;
+      return KILOBYTES.toMB(Long.parseLong(output.toString().split("\\s+")[0]));
     }
     catch (NumberFormatException e)
     {
@@ -130,6 +109,6 @@ public class DiskUtils
       File localPath = new File(CacheUtil.getDirPath(d, conf));
       used += localPath.getTotalSpace() - localPath.getUsableSpace();
     }
-    return (int) bytesToMB(used);
+    return (int) BYTES.toMB(used);
   }
 }

--- a/rubix-bookkeeper/src/test/java/com/qubole/rubix/bookkeeper/TestBookKeeper.java
+++ b/rubix-bookkeeper/src/test/java/com/qubole/rubix/bookkeeper/TestBookKeeper.java
@@ -44,6 +44,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 
+import static com.qubole.rubix.spi.utils.DataSizeUnits.BYTES;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
@@ -134,7 +135,7 @@ public class TestBookKeeper
 
     bookKeeper.readData(remotePathWithScheme, offset, (int) downloadSize, fileSize, TEST_LAST_MODIFIED, ClusterType.TEST_CLUSTER_MANAGER.ordinal());
     verifyDownloadedData(backendFileName, offset, downloadSize);
-    expectedSparseFileSize = (int) DiskUtils.bytesToMB(downloadSize);
+    expectedSparseFileSize = (int) BYTES.toMB(downloadSize);
 
     if (hasHole) {
       // Create a hole of 5 mb at 34th block
@@ -143,7 +144,7 @@ public class TestBookKeeper
       offset = offset + (int) downloadSize + holeSize; //36MB
       bookKeeper.readData(remotePathWithScheme, offset, (int) downloadSize, fileSize, TEST_LAST_MODIFIED, ClusterType.TEST_CLUSTER_MANAGER.ordinal());
       verifyDownloadedData(backendFileName, offset, downloadSize);
-      expectedSparseFileSize = (int) DiskUtils.bytesToMB(2 * downloadSize);
+      expectedSparseFileSize = (int) BYTES.toMB(2 * downloadSize);
     }
 
     long sparseFileSize = DiskUtils.getDirectorySizeInMB(new File(CacheUtil.getLocalPath(remotePathWithScheme, conf)));
@@ -404,7 +405,7 @@ public class TestBookKeeper
     bookKeeper.readData(remotePathWithScheme, readOffset, readLength, TEST_FILE_LENGTH, TEST_LAST_MODIFIED, ClusterType.TEST_CLUSTER_MANAGER.ordinal());
 
     final long mdSize = FileUtils.sizeOf(new File(CacheUtil.getMetadataFilePath(TEST_REMOTE_PATH, conf)));
-    final int totalCacheSize = (int) DiskUtils.bytesToMB(readLength + mdSize);
+    final int totalCacheSize = (int) BYTES.toMB(readLength + mdSize);
     assertEquals(metrics.getGauges().get(BookKeeperMetrics.CacheMetric.CACHE_SIZE_GAUGE.getMetricName()).getValue(), totalCacheSize);
   }
 

--- a/rubix-bookkeeper/src/test/java/com/qubole/rubix/bookkeeper/TestFileDownloader.java
+++ b/rubix-bookkeeper/src/test/java/com/qubole/rubix/bookkeeper/TestFileDownloader.java
@@ -43,6 +43,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
 import static com.qubole.rubix.spi.ClusterType.TEST_CLUSTER_MANAGER;
+import static com.qubole.rubix.spi.utils.DataSizeUnits.BYTES;
 import static org.testng.Assert.assertTrue;
 
 /**
@@ -160,7 +161,7 @@ public class TestFileDownloader
     assertTrue(expectedDownloadedDataSize == dataDownloaded, "Download size didn't match");
 
     assertTrue(metrics.getCounters().get(BookKeeperMetrics.CacheMetric.ASYNC_DOWNLOADED_MB_COUNT.getMetricName())
-        .getCount() == DiskUtils.bytesToMB(expectedDownloadedDataSize), "Total downloaded bytes didn't match");
+        .getCount() == BYTES.toMB(expectedDownloadedDataSize), "Total downloaded bytes didn't match");
 
     cacheStatus = bookKeeper.getCacheStatus(request);
 
@@ -234,7 +235,7 @@ public class TestFileDownloader
     assertTrue(expectedDownloadedDataSize == dataDownloaded, "Download size didn't match");
 
     assertTrue(metrics.getCounters().get(BookKeeperMetrics.CacheMetric.ASYNC_DOWNLOADED_MB_COUNT.getMetricName())
-            .getCount() == DiskUtils.bytesToMB(expectedDownloadedDataSize), "Total downloaded bytes didn't match");
+            .getCount() == BYTES.toMB(expectedDownloadedDataSize), "Total downloaded bytes didn't match");
 
     // Now create new fetch requests such that some blocks are overlapping with already fetched blocks
     contextMap.clear();

--- a/rubix-client/src/test/java/com/qubole/rubix/client/robotframework/BookKeeperClientRFLibrary.java
+++ b/rubix-client/src/test/java/com/qubole/rubix/client/robotframework/BookKeeperClientRFLibrary.java
@@ -41,6 +41,8 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
+import static com.qubole.rubix.spi.utils.DataSizeUnits.BYTES;
+
 public class BookKeeperClientRFLibrary
 {
   private final BookKeeperFactory factory = new BookKeeperFactory();
@@ -187,7 +189,7 @@ public class BookKeeperClientRFLibrary
       cacheSize += cacheDirSize;
     }
 
-    return (cacheSize / 1024 / 1024);
+    return BYTES.toMB(cacheSize);
   }
 
   /**

--- a/rubix-core/src/main/java/com/qubole/rubix/core/utils/DummyClusterManager.java
+++ b/rubix-core/src/main/java/com/qubole/rubix/core/utils/DummyClusterManager.java
@@ -20,12 +20,14 @@ import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.List;
 
+import static com.qubole.rubix.spi.utils.DataSizeUnits.MEGABYTES;
+
 /**
  * Created by Abhishek on 6/8/18.
  */
 public class DummyClusterManager extends ClusterManager
 {
-  private static long splitSize = 64 * 1024 * 1024;
+  private static long splitSize = MEGABYTES.toBytes(64);
   @Override
   public List<String> getNodes()
   {

--- a/rubix-spi/src/main/java/com/qubole/rubix/spi/CacheConfig.java
+++ b/rubix-spi/src/main/java/com/qubole/rubix/spi/CacheConfig.java
@@ -100,7 +100,7 @@ public class CacheConfig
   private static final String KEY_ENABLE_FILE_STALESSNESS_CHECK = "rubix.cache.file.staleness-check.enable";
   private static final String KEY_STALE_FILEINFO_EXPIRY_PERIOD = "rubix.cache.stale.fileinfo.expiry.period";
   private static final String KEY_CLEANUP_FILES_DURING_START = "rubix.cache.cleanup.files.during.start";
-  private static final String KEY_MAX_CACHE_SIZE = "rubix.cache.max.size";
+  private static final String KEY_MAX_CACHE_SIZE_IN_MB = "rubix.cache.max.size.mb";
   private static final String KEY_CACHE_FILE_SPLIT_SIZE = "rubix.cache.filesplit.size";
   private static final String KEY_CLUSTER_NODE_REFRESH_TIME = "rubix.cluster.node.refresh.time";
   private static final String KEY_DUMMY_MODE = "rubix.cache.dummy.mode";
@@ -218,9 +218,9 @@ public class CacheConfig
     return conf.getInt(KEY_DATA_CACHE_FULLNESS, DEFAULT_DATA_CACHE_FULLNESS);
   }
 
-  public static long getCacheDataFullnessMaxSize(Configuration conf)
+  public static long getCacheDataFullnessMaxSizeInMB(Configuration conf)
   {
-    return conf.getLong(KEY_MAX_CACHE_SIZE, DEFAULT_MAX_CACHE_SIZE);
+    return conf.getLong(KEY_MAX_CACHE_SIZE_IN_MB, DEFAULT_MAX_CACHE_SIZE);
   }
 
   public static String getCacheDataLocationBlacklist(Configuration conf)
@@ -848,5 +848,10 @@ public class CacheConfig
   public static void setTranportPoolMaxSize(Configuration conf, int count)
   {
     conf.setInt(KEY_POOL_MAX_SIZE, count);
+  }
+
+  public static void setMaxCacheSizeInMB(Configuration conf, long size)
+  {
+    conf.setLong(KEY_MAX_CACHE_SIZE_IN_MB, size);
   }
 }

--- a/rubix-spi/src/main/java/com/qubole/rubix/spi/CacheConfig.java
+++ b/rubix-spi/src/main/java/com/qubole/rubix/spi/CacheConfig.java
@@ -17,6 +17,8 @@ import org.apache.hadoop.conf.Configuration;
 
 import java.util.List;
 
+import static com.qubole.rubix.spi.utils.DataSizeUnits.MEGABYTES;
+
 /**
  * Created by stagra on 14/2/16.
  */
@@ -111,7 +113,7 @@ public class CacheConfig
   private static final String KEY_RUBIX_CURRENT_NODE_HOSTNAME = "current.node.hostname";
 
   // default values
-  private static final int DEFAULT_BLOCK_SIZE = 1 * 1024 * 1024; // 1MB
+  private static final int DEFAULT_BLOCK_SIZE = (int) MEGABYTES.toBytes(1);
   private static final int DEFAULT_SERVER_CONNECT_TIMEOUT = 1000; // ms
   private static final int DEFAULT_SERVER_SOCKET_TIMEOUT = 6000; // ms
   private static final int DEFAULT_KEY_POOL_MAX_SIZE = 200;
@@ -136,7 +138,7 @@ public class CacheConfig
   private static final int DEFAULT_DISK_READ_BUFFER_SIZE = 1024;
   private static final int DEFAULT_HEARTBEAT_INITIAL_DELAY = 30000; // ms
   private static final int DEFAULT_HEARTBEAT_INTERVAL = 30000; // ms
-  private static final int DEFAULT_DATA_TRANSFER_BUFFER_SIZE = 10 * 1024 * 1024; // 10MB
+  private static final int DEFAULT_DATA_TRANSFER_BUFFER_SIZE = (int) MEGABYTES.toBytes(10);
   private static final int DEFAULT_MAX_BUFFER_SIZE = 1024;
   private static final int DEFAULT_MAX_RETRIES = 3;
   private static final boolean DEFAULT_METRICS_CACHE_ENABLED = true;
@@ -170,7 +172,7 @@ public class CacheConfig
   private static final int DEFAULT_STALE_FILEINFO_EXPIRY_PERIOD = 36000; // seconds
   private static final boolean DEFAULT_CLEANUP_FILES_DURING_START = true;
   private static final long DEFAULT_MAX_CACHE_SIZE = 0;
-  private static final long DEFAULT_CACHE_FILE_SPLIT_SIZE = 256 * 1024 * 1024;
+  private static final long DEFAULT_CACHE_FILE_SPLIT_SIZE = MEGABYTES.toBytes(256);
   private static final int DEFAULT_CLUSTER_NODE_REFRESH_TIME = 300; //seconds
   private static final boolean DEFAULT_DUMMY_MODE = false;
   private static final boolean DEFAULT_EMBEDDED_MODE = false;

--- a/rubix-spi/src/main/java/com/qubole/rubix/spi/utils/DataSizeUnits.java
+++ b/rubix-spi/src/main/java/com/qubole/rubix/spi/utils/DataSizeUnits.java
@@ -1,0 +1,122 @@
+/**
+ * Copyright (c) 2019. Qubole Inc
+ * Licensed under the Apache License, Version 2.0 (the License);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License. See accompanying LICENSE file.
+ */
+package com.qubole.rubix.spi.utils;
+
+// On same lines as TimeUnit
+public enum DataSizeUnits
+{
+    BYTES {
+        public long toBytes(long size)
+        {
+            return size;
+        }
+
+        public long toKB(long size)
+        {
+            return size / 1024L;
+        }
+
+        public long toMB(long size)
+        {
+            return toKB(size) / 1024L;
+        }
+
+        public long toGB(long size)
+        {
+            return toMB(size) / 1024L;
+        }
+    },
+    KILOBYTES {
+        public long toBytes(long size)
+        {
+            return size * 1024L;
+        }
+
+        public long toKB(long size)
+        {
+            return size;
+        }
+
+        public long toMB(long size)
+        {
+            return size / 1024L;
+        }
+
+        public long toGB(long size)
+        {
+            return toMB(size) / 1024L;
+        }
+    },
+    MEGABYTES {
+        public long toBytes(long size)
+        {
+            return KILOBYTES.toBytes(toKB(size));
+        }
+
+        public long toKB(long size)
+        {
+            return size * 1024L;
+        }
+
+        public long toMB(long size)
+        {
+            return size;
+        }
+
+        public long toGB(long size)
+        {
+            return size / 1024L;
+        }
+    },
+    GIGABYTES {
+        public long toBytes(long size)
+        {
+            return MEGABYTES.toBytes(toMB(size));
+        }
+
+        public long toKB(long size)
+        {
+            return MEGABYTES.toKB(toMB(size));
+        }
+
+        public long toMB(long size)
+        {
+            return size * 1024L;
+        }
+
+        public long toGB(long size)
+        {
+            return size;
+        }
+    };
+
+    public long toBytes(long size)
+    {
+        throw new AbstractMethodError();
+    }
+
+    public long toKB(long size)
+    {
+        throw new AbstractMethodError();
+    }
+
+    public long toMB(long size)
+    {
+        throw new AbstractMethodError();
+    }
+
+    public long toGB(long size)
+    {
+        throw new AbstractMethodError();
+    }
+}


### PR DESCRIPTION
fixes #404

Last Block of files is usually not aligned to Block boundary, 1MB. But
we were adding the full weight of Block, 1MB, to the Cache for such blocks.
This lead to over-estimation of Cache size and hence early evictions.

This change limits the max size of file computed by the actual file size.
Also, with this change, the weight of each file in Cache is represent by it's size in KB
instead of MB. Which means we cannot support file > 1TB in size, which is a big
enough.