### PR TITLE
Enable fileSystem cache in rubix

### DIFF
--- a/rubix-bookkeeper/src/main/java/com/qubole/rubix/bookkeeper/BookKeeper.java
+++ b/rubix-bookkeeper/src/main/java/com/qubole/rubix/bookkeeper/BookKeeper.java
@@ -577,7 +577,6 @@ public abstract class BookKeeper implements BookKeeperService.Iface
       if (inputStream != null) {
         try {
           inputStream.close();
-          fs.close();
         }
         catch (IOException e) {
           log.error("Error closing inputStream", e);

--- a/rubix-bookkeeper/src/main/java/com/qubole/rubix/bookkeeper/BookKeeperServer.java
+++ b/rubix-bookkeeper/src/main/java/com/qubole/rubix/bookkeeper/BookKeeperServer.java
@@ -107,7 +107,6 @@ public class BookKeeperServer extends Configured implements Tool
   {
     conf = new Configuration(conf);
     CacheConfig.setCacheDataEnabled(conf, false);
-    CacheConfig.disableFSCaches(conf);
 
     this.metrics = metricsRegistry;
     this.bookKeeperMetrics = new BookKeeperMetrics(conf, metrics);

--- a/rubix-bookkeeper/src/main/java/com/qubole/rubix/bookkeeper/FileDownloadRequestChain.java
+++ b/rubix-bookkeeper/src/main/java/com/qubole/rubix/bookkeeper/FileDownloadRequestChain.java
@@ -149,8 +149,6 @@ public class FileDownloadRequestChain extends ReadRequestChain
       if (inputStream != null) {
         inputStream.close();
       }
-
-      fileSystem.close();
     }
   }
 

--- a/rubix-bookkeeper/src/main/java/com/qubole/rubix/bookkeeper/FileDownloader.java
+++ b/rubix-bookkeeper/src/main/java/com/qubole/rubix/bookkeeper/FileDownloader.java
@@ -104,8 +104,6 @@ class FileDownloader
       Path path = new Path(entry.getKey());
       DownloadRequestContext context = entry.getValue();
 
-      // Creating a new instance of the filesystem object by calling FileSystem.newInstance
-      // This one makes sure we will get a new instance even if fs.%.impl.disable.cache is set to false
       FileSystem fs = FileSystem.get(path.toUri(), conf);
       fs.initialize(path.toUri(), conf);
 

--- a/rubix-bookkeeper/src/main/java/com/qubole/rubix/bookkeeper/LocalDataTransferServer.java
+++ b/rubix-bookkeeper/src/main/java/com/qubole/rubix/bookkeeper/LocalDataTransferServer.java
@@ -88,7 +88,6 @@ public class LocalDataTransferServer extends Configured implements Tool
   {
     conf = new Configuration(conf);
     CacheConfig.setCacheDataEnabled(conf, false);
-    CacheConfig.disableFSCaches(conf);
     metrics = metricRegistry;
     registerMetrics(conf);
 

--- a/rubix-bookkeeper/src/main/java/com/qubole/rubix/bookkeeper/RemoteFetchProcessor.java
+++ b/rubix-bookkeeper/src/main/java/com/qubole/rubix/bookkeeper/RemoteFetchProcessor.java
@@ -57,8 +57,6 @@ public class RemoteFetchProcessor extends AbstractScheduledService
     // Initializing a new Config object so that it doesn't interfere with the existing one
     conf = new Configuration(conf);
 
-    // Disabling FileSystem level cache for all the schemes.
-    CacheConfig.disableFSCaches(conf);
 
     // Disable Rubix caching for cases we instantiate CachingFS objects to prevent loops
     CacheConfig.setCacheDataEnabled(conf, false);

--- a/rubix-spi/src/main/java/com/qubole/rubix/spi/CacheConfig.java
+++ b/rubix-spi/src/main/java/com/qubole/rubix/spi/CacheConfig.java
@@ -819,13 +819,4 @@ public class CacheConfig
   {
     conf.setInt(KEY_POOL_MAX_SIZE, count);
   }
-
-  public static Configuration disableFSCaches(Configuration conf)
-  {
-    List<String> fsSchemes = ImmutableList.of("s3", "s3a", "s3n", "wasb", "wasbs", "abfs", "abfss", "gs", "hdfs");
-    for (String scheme : fsSchemes) {
-      conf.setBoolean(String.format("fs.%s.impl.disable.cache", scheme), true);
-    }
-    return conf;
-  }
 }


### PR DESCRIPTION
Tested the changes with parallel warmup enabled/disabled in embedded & non-embedded mode by firing long-running tpcds catalog queries concurrently containing results parquet/orc/text format. 