### PR TITLE
Initialize embedded FileSystme once

### DIFF
--- a/rubix-core/src/main/java/com/qubole/rubix/core/CachingFileSystem.java
+++ b/rubix-core/src/main/java/com/qubole/rubix/core/CachingFileSystem.java
@@ -141,12 +141,10 @@ public abstract class CachingFileSystem<T extends FileSystem> extends FilterFile
     if (clusterManager == null) {
       throw new IOException("Cluster Manager not set");
     }
-    super.initialize(uri, conf);
+    super.initialize(getOriginalURI(uri), conf);
     this.uri = URI.create(uri.getScheme() + "://" + uri.getAuthority());
     this.workingDir = new Path("/user", System.getProperty("user.name")).makeQualified(this);
     isRubixSchemeUsed = uri.getScheme().equals(CacheConfig.RUBIX_SCHEME);
-    URI originalUri = getOriginalURI(uri);
-    fs.initialize(originalUri, conf);
   }
 
   public synchronized void initializeClusterManager(Configuration conf, ClusterType clusterType)


### PR DESCRIPTION
FilterFileSystem does initialize embedded
FileSystem as part of initialize method.
Therefore it doesn't need to be initialized again
in CachingFileSystem#initialize.