### PR TITLE
Avoid extra getFileStatus call in listLocatedStatus

### DIFF
--- a/rubix-core/src/main/java/com/qubole/rubix/core/CachingFileSystem.java
+++ b/rubix-core/src/main/java/com/qubole/rubix/core/CachingFileSystem.java
@@ -348,7 +348,7 @@ public abstract class CachingFileSystem<T extends FileSystem> extends FilterFile
           {
               LocatedFileStatus status = stats.next();
               // use caching locations explicitly
-              BlockLocation[] locations = status.isFile() ? getFileBlockLocations(status.getPath(), 0, status.getLen()) : null;
+              BlockLocation[] locations = status.isFile() ? getFileBlockLocations(status, 0, status.getLen()) : null;
               return new LocatedFileStatus(status, locations);
           }
       };


### PR DESCRIPTION
Existing `getFileBlockLocations(Path p, long start, long len)` makes `getFileStatus(p)` to get the fileStatus to pass into `getFileBlockLocations(FileStatus file, long start, long len)` which is unnecessary and causes extra cloud store calls slowing down the split generation