### PR TITLE
upgrade thrift library

### DIFF
--- a/rubix-spi/pom.xml
+++ b/rubix-spi/pom.xml
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>org.apache.thrift</groupId>
             <artifactId>libthrift</artifactId>
-            <version>0.9.3</version>
+            <version>0.13.0</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>


### PR DESCRIPTION
Upgrading thrift library to the latest one as the current one has security vulnerabilities.