### PR TITLE
shade com.google in build module

### DIFF
--- a/rubix-build/pom.xml
+++ b/rubix-build/pom.xml
@@ -84,6 +84,13 @@
                                     <pattern>org.apache.thrift</pattern>
                                     <shadedPattern>org.apache.thrift.shaded</shadedPattern>
                                 </relocation>
+                                <relocation>
+                                    <pattern>com.google</pattern>
+                                    <shadedPattern>com.google.shaded</shadedPattern>
+                                    <excludes>
+                                        <exclude>com.google.cloud.**</exclude>
+                                    </excludes>
+                                </relocation>
                             </relocations>
 
                         </configuration>


### PR DESCRIPTION
build will fail in the client using rubix build as jar with duplicate class.
Made similar to presto-shaded module.