### PR TITLE
Minimize error in space usage accounting

### DIFF
--- a/rubix-bookkeeper/src/main/java/com/qubole/rubix/bookkeeper/FileDownloadRequestChain.java
+++ b/rubix-bookkeeper/src/main/java/com/qubole/rubix/bookkeeper/FileDownloadRequestChain.java
@@ -64,7 +64,7 @@ public class FileDownloadRequestChain extends ReadRequestChain
       long lastModified,
       int generationNumber)
   {
-    super(generationNumber);
+    super(generationNumber, getBlockAlignedMaxChunkSize(conf));
     this.bookKeeper = bookKeeper;
     this.remoteFileSystem = remoteFileSystem;
     this.localFile = localfile;
@@ -74,6 +74,13 @@ public class FileDownloadRequestChain extends ReadRequestChain
     this.lastModified = lastModified;
     this.directBuffer = directBuffer;
     this.maxRemoteReadBufferSize = CacheConfig.getDataTransferBufferSize(conf);
+  }
+
+  private static long getBlockAlignedMaxChunkSize(Configuration conf)
+  {
+    long maxReadRequestLength = CacheConfig.getParallelWarmupMaxChunkSize(conf);
+    long blockSize = CacheConfig.getBlockSize(conf);
+    return (maxReadRequestLength / blockSize) * blockSize;
   }
 
   public String getRemotePath()

--- a/rubix-bookkeeper/src/main/java/com/qubole/rubix/bookkeeper/FileDownloadRequestChain.java
+++ b/rubix-bookkeeper/src/main/java/com/qubole/rubix/bookkeeper/FileDownloadRequestChain.java
@@ -134,7 +134,7 @@ public class FileDownloadRequestChain extends ReadRequestChain
     FileChannel fileChannel = null;
     FileSystem fileSystem = remoteFileSystem;
     try {
-      inputStream = fileSystem.open(new Path(remotePath), CacheConfig.getBlockSize(conf));
+      inputStream = fileSystem.open(new Path(remotePath));
       fileChannel = new FileOutputStream(new RandomAccessFile(file, "rw").getFD()).getChannel();
       for (ReadRequest readRequest : readRequests) {
         if (isCancelled()) {

--- a/rubix-bookkeeper/src/main/java/com/qubole/rubix/bookkeeper/FileDownloader.java
+++ b/rubix-bookkeeper/src/main/java/com/qubole/rubix/bookkeeper/FileDownloader.java
@@ -214,12 +214,7 @@ class FileDownloader
       }
       try {
         long read = future.get();
-        // Updating the cache only when we have downloaded the same amount of data that we requested
-        // This takes care of the scenario where the data is download partially but the cache
-        // metadata gets updated for all the requested blocks.
         if (read == totalBytesToBeDownloaded) {
-          requestChain.updateCacheStatus(requestChain.getRemotePath(), requestChain.getFileSize(),
-              requestChain.getLastModified(), CacheConfig.getBlockSize(conf), conf);
           stats.addReadRequestChainStats(requestChain.getStats());
           sizeRead += read;
           this.totalTimeToDownload.inc(requestChain.getTimeSpentOnDownload());

--- a/rubix-bookkeeper/src/test/java/com/qubole/rubix/bookkeeper/TestFileDownloader.java
+++ b/rubix-bookkeeper/src/test/java/com/qubole/rubix/bookkeeper/TestFileDownloader.java
@@ -20,6 +20,7 @@ import com.qubole.rubix.common.metrics.BookKeeperMetrics;
 import com.qubole.rubix.common.utils.DataGen;
 import com.qubole.rubix.common.utils.TestUtil;
 import com.qubole.rubix.core.ClusterManagerInitilizationException;
+import com.qubole.rubix.core.ReadRequestChain;
 import com.qubole.rubix.spi.CacheConfig;
 import com.qubole.rubix.spi.CacheUtil;
 import com.qubole.rubix.spi.ClusterType;
@@ -121,6 +122,7 @@ public class TestFileDownloader
     context.addDownloadRange(500, 800);
 
     final List<FileDownloadRequestChain> requestChains = downloader.getFileDownloadRequestChains(contextMap);
+    requestChains.stream().forEach(ReadRequestChain::lock);
 
     assertTrue(requestChains.size() == 2,
         "Wrong Number of Request Chains. Expected = 2 Got = " + requestChains.size());

--- a/rubix-core/src/main/java/com/qubole/rubix/core/ReadRequest.java
+++ b/rubix-core/src/main/java/com/qubole/rubix/core/ReadRequest.java
@@ -13,6 +13,9 @@
 package com.qubole.rubix.core;
 
 import java.util.Arrays;
+import java.util.Objects;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
 
 /**
  * Created by stagra on 4/1/16.
@@ -160,5 +163,49 @@ public class ReadRequest
     otherRequest.backendFileSize = this.backendFileSize;
 
     return otherRequest;
+  }
+
+  @Override
+  public boolean equals (Object o)
+  {
+    if (this == o) {
+      return true;
+    }
+
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    ReadRequest that = (ReadRequest) o;
+
+    return backendReadStart == that.backendReadStart &&
+            backendReadEnd == that.backendReadEnd &&
+            actualReadStart == that.actualReadStart &&
+            actualReadEnd == that.actualReadEnd &&
+            destBufferOffset == that.destBufferOffset &&
+            backendFileSize == that.backendFileSize &&
+            Arrays.equals(destBuffer, that.destBuffer);
+  }
+
+  @Override
+  public int hashCode ()
+  {
+    int result = Objects.hash(backendReadStart, backendReadEnd, actualReadStart, actualReadEnd, destBufferOffset, backendFileSize);
+    result = 31 * result + Arrays.hashCode(destBuffer);
+    return result;
+  }
+
+  @Override
+  public String toString ()
+  {
+    return toStringHelper(this)
+            .add("backendReadStart", backendReadStart)
+            .add("backendReadEnd", backendReadEnd)
+            .add("actualReadStart", actualReadStart)
+            .add("actualReadEnd", actualReadEnd)
+            .add("destBuffer", destBuffer)
+            .add("destBufferOffset", destBufferOffset)
+            .add("backendFileSize", backendFileSize)
+            .toString();
   }
 }

--- a/rubix-core/src/main/java/com/qubole/rubix/core/ReadRequestChain.java
+++ b/rubix-core/src/main/java/com/qubole/rubix/core/ReadRequestChain.java
@@ -71,7 +71,6 @@ public abstract class ReadRequestChain implements Callable<Long>
   public void addReadRequest(ReadRequest readRequest)
   {
     checkState(!isLocked, "Adding request to a locked chain");
-    log.debug(String.format("Request to add ReadRequest: [%d, %d, %d, %d, %d]", readRequest.getBackendReadStart(), readRequest.getBackendReadEnd(), readRequest.getActualReadStart(), readRequest.getActualReadEnd(), readRequest.getDestBufferOffset()));
     if (lastRequest == null) {
       lastRequest = readRequest;
     }
@@ -81,7 +80,6 @@ public abstract class ReadRequestChain implements Callable<Long>
         // Since the ReadRequests coming in are for same buffer, can merge the two
         lastRequest.setBackendReadEnd(readRequest.getBackendReadEnd());
         lastRequest.setActualReadEnd(readRequest.getActualReadEnd());
-        log.debug(String.format("Updated last to: [%d, %d, %d, %d, %d]", lastRequest.getBackendReadStart(), lastRequest.getBackendReadEnd(), lastRequest.getActualReadStart(), lastRequest.getActualReadEnd(), lastRequest.getDestBufferOffset()));
       }
       else {
         addRequest(lastRequest);

--- a/rubix-spi/src/main/java/com/qubole/rubix/spi/CacheConfig.java
+++ b/rubix-spi/src/main/java/com/qubole/rubix/spi/CacheConfig.java
@@ -108,6 +108,7 @@ public class CacheConfig
   private static final String KEY_DUMMY_MODE = "rubix.cache.dummy.mode";
   private static final String KEY_EMBEDDED_MODE = "rubix.cluster.embedded.mode";
   private static final String KEY_HEARTBEAT_ENABLED = "rubix.cluster.heartbeat.enabled";
+  private static final String KEY_PARALLEL_WARMUP_MAX_CHUNK_SIZE = "rubix.cache.parallel.warmup.max_chunk_size";
 
   // Internal Configurations used in RubiX
   private static final String KEY_YARN_RESOURCEMANAGER_ADDRESS = "yarn.resourcemanager.address";
@@ -183,6 +184,7 @@ public class CacheConfig
   private static final boolean DEFAULT_EMBEDDED_MODE = false;
   public static final String DEFAULT_RUBIX_SITE_LOCATION = "/usr/lib/rubix/etc/rubix-site.xml";
   private static final boolean DEFAULT_HEARTBEAT_ENABLED = true;
+  private static final long DEFAULT_PARALLEL_WARMUP_MAX_CHUNK_SIZE = MEGABYTES.toBytes(100);
 
   private CacheConfig()
   {
@@ -576,6 +578,11 @@ public class CacheConfig
     return conf.get(KEY_RUBIX_CURRENT_NODE_HOSTNAME, null);
   }
 
+  public static long getParallelWarmupMaxChunkSize (Configuration conf)
+  {
+    return conf.getLong(KEY_PARALLEL_WARMUP_MAX_CHUNK_SIZE, DEFAULT_PARALLEL_WARMUP_MAX_CHUNK_SIZE);
+  }
+
   public static void setRubixConfigApplied(Configuration conf, boolean value)
   {
     conf.setBoolean(KEY_RUBIX_SITE_CONFIG_APPLIED, value);
@@ -879,5 +886,10 @@ public class CacheConfig
   public static void setMaxCacheSizeInMB(Configuration conf, long size)
   {
     conf.setLong(KEY_MAX_CACHE_SIZE_IN_MB, size);
+  }
+
+  public static void setParallelWarmupMaxChunkSize(Configuration conf, long size)
+  {
+    conf.setLong(KEY_PARALLEL_WARMUP_MAX_CHUNK_SIZE, size);
   }
 }


### PR DESCRIPTION
Fixes #463 

Main changes:
1. Limit the size of each readRequest in FileDownloadRequestChain to 100MB
2. With the download of each readRequest itself update the metadata instead of existing behavior of downloading all the data in the Chain and then updating metadata

This ensures we will never cross over the configured threshold of disk utilization by 1GB. This crossing over is actually partially handled by only considering 95% of disk space as available, keeping 5% as buffer space for this cross over but in existing warmup scenario we could cross the limit by a much bigger margin.
